### PR TITLE
Don't check size of the last POS file

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -99,7 +99,7 @@ pub(crate) fn read_data(
 
         // If there are more files, check if the size of the file is correct
         if files.peek().is_some() && pos_file_size != file_size {
-            eprintln!("too short POS file: {pos_file_size}, <  {file_size}");
+            eprintln!("invalid POS file, expected size: {file_size} vs actual size: {pos_file_size}");
         }
         readers.push(BatchingReader::new(file, pos, batch_size, file_size));
     }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -99,7 +99,9 @@ pub(crate) fn read_data(
 
         // If there are more files, check if the size of the file is correct
         if files.peek().is_some() && pos_file_size != file_size {
-            eprintln!("invalid POS file, expected size: {file_size} vs actual size: {pos_file_size}");
+            eprintln!(
+                "invalid POS file, expected size: {file_size} vs actual size: {pos_file_size}"
+            );
         }
         readers.push(BatchingReader::new(file, pos, batch_size, file_size));
     }


### PR DESCRIPTION
Previously it wrongly reported a corrupted POS data if the last file was smaller than _max file size_. It's fine, the last file can be smaller.