### PR TITLE
Proper logging instead of prints.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,17 +474,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
-name = "colored"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
-dependencies = [
- "atty",
- "lazy_static",
- "winapi",
-]
-
-[[package]]
 name = "constant_time_eq"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1325,15 +1314,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "object"
 version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1477,7 +1457,6 @@ dependencies = [
  "log",
  "post-rs",
  "scrypt-ocl",
- "simple_logger",
 ]
 
 [[package]]
@@ -1943,19 +1922,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
-name = "simple_logger"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78beb34673091ccf96a8816fce8bfd30d1292c7621ca2bcb5f2ba0fae4f558d"
-dependencies = [
- "atty",
- "colored",
- "log",
- "time",
- "windows-sys 0.42.0",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2106,8 +2072,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
 dependencies = [
  "itoa",
- "libc",
- "num_threads",
  "serde",
  "time-core",
  "time-macros",
@@ -2327,21 +2291,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
  "windows-targets 0.48.0",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,6 +731,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -975,6 +988,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "iana-time-zone"
@@ -1453,7 +1472,9 @@ name = "post-cbindings"
 version = "0.1.8"
 dependencies = [
  "cbindgen",
+ "env_logger",
  "eyre",
+ "log",
  "post-rs",
  "scrypt-ocl",
 ]
@@ -1470,6 +1491,7 @@ dependencies = [
  "criterion",
  "eyre",
  "itertools",
+ "log",
  "pprof",
  "proptest",
  "rand",
@@ -1841,6 +1863,7 @@ dependencies = [
 name = "scrypt-ocl"
 version = "0.1.8"
 dependencies = [
+ "log",
  "ocl",
  "post-rs",
  "rstest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,6 +731,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -977,6 +990,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1047,6 +1066,7 @@ version = "0.1.8"
 dependencies = [
  "base64 0.21.0",
  "clap 4.2.4",
+ "env_logger",
  "eyre",
  "post-rs",
  "rand",
@@ -1536,6 +1556,7 @@ name = "profiler"
 version = "0.1.0"
 dependencies = [
  "clap 4.2.4",
+ "env_logger",
  "eyre",
  "post-rs",
  "rayon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,6 +474,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "colored"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -731,19 +742,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -988,12 +986,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "iana-time-zone"
@@ -1333,6 +1325,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1472,11 +1473,11 @@ name = "post-cbindings"
 version = "0.1.8"
 dependencies = [
  "cbindgen",
- "env_logger",
  "eyre",
  "log",
  "post-rs",
  "scrypt-ocl",
+ "simple_logger",
 ]
 
 [[package]]
@@ -1942,6 +1943,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
+name = "simple_logger"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78beb34673091ccf96a8816fce8bfd30d1292c7621ca2bcb5f2ba0fae4f558d"
+dependencies = [
+ "atty",
+ "colored",
+ "log",
+ "time",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2092,6 +2106,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
 dependencies = [
  "itoa",
+ "libc",
+ "num_threads",
  "serde",
  "time-core",
  "time-macros",
@@ -2311,6 +2327,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
  "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ blake3 = "1.3.3"
 bitvec = "1.0.1"
 rayon = "1.6.1"
 rand = "0.8.5"
+log = "0.4.17"
 
 [dev-dependencies]
 criterion = "0.4"

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -10,10 +10,9 @@ crate_type = ["staticlib", "cdylib"]
 
 [dependencies]
 eyre = "0.6.8"
-log = "0.4.17"
+log = { version = "0.4.17", features = ["std"] }
 post-rs = { path = "../" }
 scrypt-ocl = { path = "../scrypt-ocl" }
-simple_logger = "4.1.0"
 
 [build-dependencies]
 cbindgen = "*"

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -9,11 +9,11 @@ name = "post"
 crate_type = ["staticlib", "cdylib"]
 
 [dependencies]
-env_logger = "0.10.0"
 eyre = "0.6.8"
 log = "0.4.17"
 post-rs = { path = "../" }
 scrypt-ocl = { path = "../scrypt-ocl" }
+simple_logger = "4.1.0"
 
 [build-dependencies]
 cbindgen = "*"

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -9,7 +9,9 @@ name = "post"
 crate_type = ["staticlib", "cdylib"]
 
 [dependencies]
+env_logger = "0.10.0"
 eyre = "0.6.8"
+log = "0.4.17"
 post-rs = { path = "../" }
 scrypt-ocl = { path = "../scrypt-ocl" }
 

--- a/ffi/build.rs
+++ b/ffi/build.rs
@@ -9,7 +9,7 @@ fn main() {
         .with_language(cbindgen::Language::C)
         .with_crate(crate_dir)
         .with_parse_deps(true)
-        .with_parse_include(&["post-rs", "scrypt-jane"])
+        .with_parse_include(&["post-rs", "scrypt-jane", "log"])
         .generate()
         .expect("Unable to generate bindings")
         .write_to_file("prover.h");

--- a/ffi/src/initialization.rs
+++ b/ffi/src/initialization.rs
@@ -164,7 +164,7 @@ pub extern "C" fn new_initializer(
     match _new_initializer(provider_id, n, commitment, vrf_difficulty) {
         Ok(initializer) => initializer,
         Err(e) => {
-            eprintln!("Error creating initializer: {e:?}");
+            log::error!("Error creating initializer: {e:?}");
             std::ptr::null_mut()
         }
     }
@@ -329,6 +329,5 @@ mod tests {
             InitializeResult::InitializeOk,
             super::get_providers(providers.as_mut_ptr(), count)
         );
-        println!("{providers:?}");
     }
 }

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1,4 +1,5 @@
 mod initialization;
+mod log;
 mod post_impl;
 
 #[repr(C)]

--- a/ffi/src/log.rs
+++ b/ffi/src/log.rs
@@ -1,7 +1,25 @@
 pub use log::LevelFilter;
+use simple_logger::SimpleLogger;
 
 /// Configure logging for the library.
 #[no_mangle]
-pub extern "C" fn configure_logging(level: log::LevelFilter) {
-    env_logger::Builder::new().filter_level(level).init();
+pub extern "C" fn configure_logging(level: LevelFilter) -> i32 {
+    match SimpleLogger::new().with_level(level).init() {
+        Ok(_) => 0,
+        Err(e) => {
+            eprintln!("Failed to initialize logging: {e:?}");
+            -1
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn configuring_logging() {
+        assert_eq!(log::LevelFilter::Off, log::max_level());
+        let result = super::configure_logging(log::LevelFilter::Info);
+        assert_eq!(0, result);
+        assert_eq!(log::LevelFilter::Info, log::max_level());
+    }
 }

--- a/ffi/src/log.rs
+++ b/ffi/src/log.rs
@@ -1,9 +1,16 @@
+use std::{
+    fmt::{Debug, Formatter},
+    mem::ManuallyDrop,
+    sync::Once,
+};
+
 pub use log::LevelFilter;
+use log::{Level, Log, Metadata, Record};
 use simple_logger::SimpleLogger;
 
 /// Configure logging for the library.
 #[no_mangle]
-pub extern "C" fn configure_logging(level: LevelFilter) -> i32 {
+pub extern "C" fn set_log_level(level: LevelFilter) -> i32 {
     match SimpleLogger::new().with_level(level).init() {
         Ok(_) => 0,
         Err(e) => {
@@ -13,13 +20,168 @@ pub extern "C" fn configure_logging(level: LevelFilter) -> i32 {
     }
 }
 
+/// FFI-safe borrowed Rust &str. Can represent `Option<&str>` by setting ptr to null.
+#[repr(C)]
+pub struct CStr {
+    pub ptr: *const u8,
+    pub len: usize,
+}
+
+impl CStr {
+    pub unsafe fn to_str<'a>(&self) -> &'a str {
+        let bytes = std::slice::from_raw_parts(self.ptr, self.len);
+        std::str::from_utf8_unchecked(bytes)
+    }
+}
+
+impl<'a> From<&'a str> for CStr {
+    fn from(s: &'a str) -> Self {
+        Self {
+            ptr: s.as_ptr(),
+            len: s.len(),
+        }
+    }
+}
+
+impl From<Option<&str>> for CStr {
+    fn from(other: Option<&str>) -> Self {
+        if let Some(s) = other {
+            Self::from(s)
+        } else {
+            Self {
+                ptr: std::ptr::null(),
+                len: 0,
+            }
+        }
+    }
+}
+
+/// FFI-safe owned Rust String.
+#[repr(C)]
+pub struct CString {
+    pub ptr: *mut u8,
+    pub cap: usize,
+    pub len: usize,
+}
+
+impl CString {
+    unsafe fn to_str<'a>(&self) -> &'a str {
+        CStr {
+            ptr: self.ptr,
+            len: self.len,
+        }
+        .to_str()
+    }
+}
+
+impl From<String> for CString {
+    fn from(s: String) -> Self {
+        let mut me = ManuallyDrop::new(s);
+        let (ptr, len, cap) = (me.as_mut_ptr(), me.len(), me.capacity());
+        Self { ptr, len, cap }
+    }
+}
+
+impl Drop for CString {
+    fn drop(&mut self) {
+        unsafe {
+            String::from_raw_parts(self.ptr, self.len, self.cap);
+        }
+    }
+}
+
+impl Debug for CString {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        unsafe { self.to_str() }.fmt(f)
+    }
+}
+
+impl Debug for CStr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        unsafe { self.to_str() }.fmt(f)
+    }
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct ExternCRecord {
+    pub level: Level,
+    pub message: CString,  // Preformatted message
+    pub module_path: CStr, // None points to null
+    pub file: CStr,        // None points to null
+    pub line: i64,         // None maps to -1, everything else should fit in u32.
+}
+
+impl<'a> From<&Record<'a>> for ExternCRecord {
+    fn from(record: &Record<'a>) -> Self {
+        Self {
+            level: record.level(),
+            message: CString::from(record.args().to_string()),
+            module_path: CStr::from(record.module_path()),
+            file: CStr::from(record.file()),
+            line: record.line().map(|u| u as i64).unwrap_or(-1_i64),
+        }
+    }
+}
+
+static mut LOGGER: Option<ExternCLog> = None;
+static SET_LOGGER: Once = Once::new();
+
+struct ExternCLog {
+    callback: extern "C" fn(&ExternCRecord),
+}
+
+impl ExternCLog {
+    fn new(callback: extern "C" fn(&ExternCRecord)) -> Self {
+        Self { callback }
+    }
+}
+
+impl Log for ExternCLog {
+    fn enabled(&self, _metadata: &Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &Record) {
+        (self.callback)(&ExternCRecord::from(record));
+    }
+
+    fn flush(&self) {}
+}
+
+/// Set the logging callback function that accepts a *const c_char.
+/// The function is idempotent, calling it more then once will have no effect.
+#[no_mangle]
+pub extern "C" fn set_logging_callback(callback: extern "C" fn(&ExternCRecord)) {
+    SET_LOGGER.call_once(|| {
+        unsafe {
+            LOGGER = Some(ExternCLog::new(callback));
+            _ = log::set_logger(LOGGER.as_ref().unwrap());
+        }
+        log::set_max_level(log::LevelFilter::Trace);
+    });
+}
+
 #[cfg(test)]
 mod tests {
+    use crate::log::ExternCRecord;
+
     #[test]
     fn configuring_logging() {
-        assert_eq!(log::LevelFilter::Off, log::max_level());
-        let result = super::configure_logging(log::LevelFilter::Info);
+        let result = super::set_log_level(log::LevelFilter::Info);
         assert_eq!(0, result);
-        assert_eq!(log::LevelFilter::Info, log::max_level());
+
+        log::info!("Hello, world!");
+    }
+
+    #[test]
+    fn logging_callback() {
+        extern "C" fn log_cb(record: &ExternCRecord) {
+            assert_eq!("Hello, logger", unsafe { record.message.to_str() });
+            assert_eq!(log::Level::Info, record.level);
+        }
+
+        super::set_logging_callback(log_cb);
+        log::info!("Hello, logger");
     }
 }

--- a/ffi/src/log.rs
+++ b/ffi/src/log.rs
@@ -67,6 +67,8 @@ impl Log for ExternCLog {
 }
 
 /// Set a logging callback function
+/// The function is idempotent, calling it more then once will have no effect.
+/// Returns 0 if the callback was set successfully, 1 otherwise.
 #[no_mangle]
 pub extern "C" fn set_logging_callback(
     level: Level,

--- a/ffi/src/log.rs
+++ b/ffi/src/log.rs
@@ -1,0 +1,7 @@
+pub use log::LevelFilter;
+
+/// Configure logging for the library.
+#[no_mangle]
+pub extern "C" fn configure_logging(level: log::LevelFilter) {
+    env_logger::Builder::new().filter_level(level).init();
+}

--- a/ffi/src/log.rs
+++ b/ffi/src/log.rs
@@ -1,122 +1,46 @@
-use std::{
-    fmt::{Debug, Formatter},
-    mem::ManuallyDrop,
-};
+use std::ffi::c_char;
 
-pub use log::LevelFilter;
 use log::{Level, Log, Metadata, Record};
 
-/// FFI-safe borrowed Rust &str. Can represent `Option<&str>` by setting ptr to null.
+/// FFI-safe borrowed Rust &str
 #[repr(C)]
-pub struct CStr {
-    pub ptr: *const u8,
+pub struct StringView {
+    pub ptr: *const c_char,
     pub len: usize,
 }
 
-impl CStr {
+impl StringView {
     pub unsafe fn to_str<'a>(&self) -> &'a str {
-        let bytes = std::slice::from_raw_parts(self.ptr, self.len);
+        let bytes = std::slice::from_raw_parts(self.ptr as _, self.len);
         std::str::from_utf8_unchecked(bytes)
     }
 }
 
-impl<'a> From<&'a str> for CStr {
+impl<'a> From<&'a str> for StringView {
     fn from(s: &'a str) -> Self {
         Self {
-            ptr: s.as_ptr(),
+            ptr: s.as_ptr() as _,
             len: s.len(),
         }
     }
 }
 
-impl From<Option<&str>> for CStr {
-    fn from(other: Option<&str>) -> Self {
-        if let Some(s) = other {
-            Self::from(s)
-        } else {
-            Self {
-                ptr: std::ptr::null(),
-                len: 0,
-            }
-        }
-    }
-}
-
-/// FFI-safe owned Rust String.
 #[repr(C)]
-pub struct CString {
-    pub ptr: *mut u8,
-    pub cap: usize,
-    pub len: usize,
-}
-
-impl CString {
-    unsafe fn to_str<'a>(&self) -> &'a str {
-        CStr {
-            ptr: self.ptr,
-            len: self.len,
-        }
-        .to_str()
-    }
-}
-
-impl From<String> for CString {
-    fn from(s: String) -> Self {
-        let mut me = ManuallyDrop::new(s);
-        let (ptr, len, cap) = (me.as_mut_ptr(), me.len(), me.capacity());
-        Self { ptr, len, cap }
-    }
-}
-
-impl Drop for CString {
-    fn drop(&mut self) {
-        unsafe {
-            String::from_raw_parts(self.ptr, self.len, self.cap);
-        }
-    }
-}
-
-impl Debug for CString {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        unsafe { self.to_str() }.fmt(f)
-    }
-}
-
-impl Debug for CStr {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        unsafe { self.to_str() }.fmt(f)
-    }
-}
-
-#[repr(C)]
-#[derive(Debug)]
 pub struct ExternCRecord {
     pub level: Level,
-    pub message: CString,  // Preformatted message
-    pub module_path: CStr, // None points to null
-    pub file: CStr,        // None points to null
-    pub line: i64,         // None maps to -1, everything else should fit in u32.
-}
-
-impl<'a> From<&Record<'a>> for ExternCRecord {
-    fn from(record: &Record<'a>) -> Self {
-        Self {
-            level: record.level(),
-            message: CString::from(record.args().to_string()),
-            module_path: CStr::from(record.module_path()),
-            file: CStr::from(record.file()),
-            line: record.line().map(|u| u as i64).unwrap_or(-1_i64),
-        }
-    }
+    pub message: StringView,
+    pub module_path: StringView,
+    pub file: StringView,
+    pub line: i64,
 }
 
 struct ExternCLog {
     callback: extern "C" fn(&ExternCRecord),
-    level: LevelFilter,
+    level: Level,
 }
 
 impl ExternCLog {
-    fn new(level: LevelFilter, callback: extern "C" fn(&ExternCRecord)) -> Self {
+    fn new(level: Level, callback: extern "C" fn(&ExternCRecord)) -> Self {
         Self { level, callback }
     }
 }
@@ -127,7 +51,16 @@ impl Log for ExternCLog {
     }
 
     fn log(&self, record: &Record) {
-        (self.callback)(&ExternCRecord::from(record));
+        let msg = record.args().to_string();
+        let c_record = ExternCRecord {
+            level: record.level(),
+            message: StringView::from(msg.as_str()),
+            module_path: StringView::from(record.module_path().unwrap_or("")),
+            file: StringView::from(record.file().unwrap_or("")),
+            line: record.line().map(|u| u as i64).unwrap_or(-1_i64),
+        };
+
+        (self.callback)(&c_record);
     }
 
     fn flush(&self) {}
@@ -136,11 +69,11 @@ impl Log for ExternCLog {
 /// Set a logging callback function
 #[no_mangle]
 pub extern "C" fn set_logging_callback(
-    level: LevelFilter,
+    level: Level,
     callback: extern "C" fn(&ExternCRecord),
 ) -> i32 {
     match log::set_boxed_logger(Box::new(ExternCLog::new(level, callback)))
-        .map(|()| log::set_max_level(level))
+        .map(|()| log::set_max_level(level.to_level_filter()))
     {
         Ok(_) => 0,
         Err(e) => {
@@ -161,13 +94,10 @@ mod tests {
             assert_eq!(log::Level::Info, record.level);
         }
 
-        super::set_logging_callback(log::LevelFilter::Info, log_cb);
+        super::set_logging_callback(log::Level::Info, log_cb);
         log::info!("Hello, logger");
         log::trace!("Trace log level is disabled");
 
-        assert_eq!(
-            1,
-            super::set_logging_callback(log::LevelFilter::Warn, log_cb)
-        );
+        assert_eq!(1, super::set_logging_callback(log::Level::Warn, log_cb));
     }
 }

--- a/ffi/src/log.rs
+++ b/ffi/src/log.rs
@@ -10,6 +10,7 @@ pub struct StringView {
 }
 
 impl StringView {
+    #[cfg(test)]
     pub unsafe fn to_str<'a>(&self) -> &'a str {
         let bytes = std::slice::from_raw_parts(self.ptr as _, self.len);
         std::str::from_utf8_unchecked(bytes)

--- a/ffi/src/post_impl.rs
+++ b/ffi/src/post_impl.rs
@@ -50,7 +50,7 @@ pub extern "C" fn generate_proof(
         Ok(proof) => proof,
         Err(e) => {
             //TODO(poszu) communicate errors better
-            eprintln!("{e:?}");
+            log::error!("{e:?}");
             std::ptr::null_mut()
         }
     }
@@ -124,7 +124,7 @@ pub unsafe extern "C" fn verify_proof(
     let result = match verify(&proof, metadata, params) {
         Ok(_) => VerifyResult::Ok,
         Err(err) => {
-            eprintln!("Proof is invalid: {err}");
+            log::error!("Proof is invalid: {err}");
             VerifyResult::Invalid
         }
     };

--- a/initializer/Cargo.toml
+++ b/initializer/Cargo.toml
@@ -13,3 +13,4 @@ scrypt-ocl = { path = "../scrypt-ocl" }
 rayon = "1.7.0"
 eyre = "0.6.8"
 rand = "0.8.5"
+env_logger = "0.10.0"

--- a/initializer/src/main.rs
+++ b/initializer/src/main.rs
@@ -221,6 +221,7 @@ fn list_providers() -> eyre::Result<()> {
 }
 
 fn main() -> eyre::Result<()> {
+    env_logger::init();
     let args = Cli::parse();
 
     match args

--- a/profiler/Cargo.toml
+++ b/profiler/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.1.11", features = ["derive"] }
+env_logger = "0.10.0"
 eyre = "0.6.8"
 post-rs = { path = "../" }
 rayon = "1.7.0"

--- a/profiler/src/main.rs
+++ b/profiler/src/main.rs
@@ -71,6 +71,7 @@ fn file_data(path: &Path, size: u64) -> Result<std::fs::File, std::io::Error> {
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
+    env_logger::init();
     let args = Args::parse();
 
     let challenge = b"hello world, challenge me!!!!!!!";

--- a/scrypt-ocl/Cargo.toml
+++ b/scrypt-ocl/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 ocl = "0.19.4"
 thiserror = "1.0.40"
 post-rs = { path = "../" }
+log = "0.4.17"
 
 [dev-dependencies]
 post-rs = { path = "../" }

--- a/scrypt-ocl/src/lib.rs
+++ b/scrypt-ocl/src/lib.rs
@@ -134,7 +134,7 @@ impl Scrypter {
             DeviceInfoResult::MaxComputeUnits
         );
         let max_wg_size = device.max_wg_size()?;
-        println!(
+        log::debug!(
             "device memory: {} MB, max_mem_alloc_size: {} MB, max_compute_units: {max_compute_units}, max_wg_size: {max_wg_size}",
             device_memory / 1024 / 1024,
             max_mem_alloc_size / 1024 / 1024,
@@ -168,7 +168,7 @@ impl Scrypter {
         );
         let kernel_wg_size = kernel.wg_info(device, KernelWorkGroupInfo::WorkGroupSize)?;
 
-        println!("preferred_wg_size_multiple: {preferred_wg_size_multiple}, kernel_wg_size: {kernel_wg_size}");
+        log::debug!("preferred_wg_size_multiple: {preferred_wg_size_multiple}, kernel_wg_size: {kernel_wg_size}");
 
         let max_global_work_size_based_on_total_mem =
             ((device_memory - INPUT_SIZE as u64) / kernel_memory as u64) as usize;
@@ -181,7 +181,7 @@ impl Scrypter {
         let local_work_size = preferred_wg_size_multiple;
         // Round down to nearest multiple of local_work_size
         let global_work_size = (max_global_work_size / local_work_size) * local_work_size;
-        eprintln!(
+        log::debug!(
             "Using: global_work_size: {global_work_size}, local_work_size: {local_work_size}"
         );
 
@@ -190,7 +190,7 @@ impl Scrypter {
             .map(|chunk| u32::from_le_bytes(chunk.try_into().unwrap()))
             .collect();
 
-        println!("Allocating buffer for input: {INPUT_SIZE} bytes");
+        log::trace!("Allocating buffer for input: {INPUT_SIZE} bytes");
         let input = Buffer::<u32>::builder()
             .len(INPUT_SIZE / 4)
             .copy_host_slice(commitment.as_slice())
@@ -199,7 +199,7 @@ impl Scrypter {
             .build()?;
 
         let output_size = global_work_size * ENTIRE_LABEL_SIZE;
-        println!("Allocating buffer for output: {output_size} bytes");
+        log::trace!("Allocating buffer for output: {output_size} bytes");
         let output = Buffer::<u8>::builder()
             .len(output_size)
             .flags(MemFlags::new().write_only())
@@ -207,7 +207,7 @@ impl Scrypter {
             .build()?;
 
         let lookup_size = global_work_size * kernel_lookup_mem_size;
-        println!("Allocating buffer for lookup: {lookup_size} bytes");
+        log::trace!("Allocating buffer for lookup: {lookup_size} bytes");
         let lookup_memory = Buffer::<u32>::builder()
             .len(lookup_size / 4)
             .flags(MemFlags::new().host_no_access())
@@ -286,8 +286,7 @@ impl Scrypter {
                         label: nonce.label,
                     });
                     vrf_difficulty = Some(nonce.label);
-                    //TODO: remove print
-                    eprintln!("Found new smallest nonce: {best_nonce:?}");
+                    log::trace!("Found new smallest nonce: {best_nonce:?}");
                 }
             }
 
@@ -327,8 +326,7 @@ impl OpenClInitializer {
         };
         let platform = provider.platform;
         let device = provider.device;
-        // TODO remove print
-        println!("Using provider: {provider}");
+        log::trace!("Using provider: {provider}");
 
         Ok(Self {
             platform,

--- a/src/initialize.rs
+++ b/src/initialize.rs
@@ -105,7 +105,7 @@ impl Initialize for CpuInitializer {
         labels: Range<u64>,
         mut vrf_difficulty: Option<[u8; 32]>,
     ) -> Result<Option<VrfNonce>, Box<dyn Error>> {
-        println!("Initializing labels {:?}...", labels);
+        log::trace!("Initializing labels {:?}...", labels);
         let data = labels
             .clone()
             .into_par_iter()
@@ -128,8 +128,7 @@ impl Initialize for CpuInitializer {
                         label,
                     });
                     vrf_difficulty = Some(label);
-                    //TODO: remove print
-                    eprintln!("Found new smallest nonce: {best_nonce:?}");
+                    log::trace!("Found new smallest nonce: {best_nonce:?}");
                 }
             }
             writer.write_all(&label[..16])?;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -99,7 +99,7 @@ pub(crate) fn read_data(
 
         // If there are more files, check if the size of the file is correct
         if files.peek().is_some() && pos_file_size != file_size {
-            eprintln!(
+            log::warn!(
                 "invalid POS file, expected size: {file_size} vs actual size: {pos_file_size}"
             );
         }


### PR DESCRIPTION
Closes #52 
Logging for the C library can be configured by the new `pub extern "C" fn set_logging_callback(level: log::Level, callback: extern "C" fn(&ExternCRecord))` function.