### PR TITLE
Assign concrete values to DeviceClass enum

### DIFF
--- a/ffi/src/initialization.rs
+++ b/ffi/src/initialization.rs
@@ -46,6 +46,7 @@ pub const CPU_PROVIDER_ID: u32 = u32::MAX;
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum DeviceClass {
+    UNSPECIFIED,
     CPU,
     GPU,
 }

--- a/ffi/src/initialization.rs
+++ b/ffi/src/initialization.rs
@@ -46,9 +46,8 @@ pub const CPU_PROVIDER_ID: u32 = u32::MAX;
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum DeviceClass {
-    UNSPECIFIED,
-    CPU,
-    GPU,
+    CPU = 1,
+    GPU = 2,
 }
 
 impl Debug for Provider {


### PR DESCRIPTION
When returning the available devices via GRPC we also return their device class as an enum. In GRPC `0` serves a special purpose as default/unspecified in an enum: https://github.com/spacemeshos/post-rs/pull/new/device-class-unspecified

Since go-spacemesh only passes through this info from post-rs we can add the "unspecified" type here to adhere to conventions in GRPC / Protobuf.