### PR TITLE
Fix K2 pow performance on many threads

### DIFF
--- a/benches/pow.rs
+++ b/benches/pow.rs
@@ -1,26 +1,51 @@
-use std::hint::black_box;
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
 
-use criterion::{criterion_group, criterion_main, Criterion};
-
+use itertools::iproduct;
 use pprof::criterion::{Output, PProfProfiler};
+use rayon::ThreadPoolBuilder;
 use scrypt_jane::scrypt::ScryptParams;
 
 fn bench_k2_pow(c: &mut Criterion) {
-    c.bench_function("k2_pow", |b| {
-        b.iter(|| {
-            post::pow::find_k2_pow(
-                b"hello world, CHALLENGE me!!!!!!!",
-                0,
-                ScryptParams::new(6, 0, 0),
-                black_box(0x000F_FFFF_FFFF_FFFF),
-            )
-        })
-    });
+    // Base pow difficulty threshold
+    // Will be scaled up by the benchmark to see if time scales linearly
+    let difficulty_threshold = 891576961504;
+
+    let mut group = c.benchmark_group("k2_pow");
+
+    for (scale, threads) in iproduct!([1000, 100], [0, 1]) {
+        let threshold = difficulty_threshold * scale;
+        let pool = ThreadPoolBuilder::new()
+            .num_threads(threads)
+            .build()
+            .unwrap();
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!(
+                "scale={scale}/threshold={threshold}/threads={threads}"
+            )),
+            &(threshold),
+            |b, &threshold| {
+                b.iter_batched(
+                    || rand::random(),
+                    |nonce| {
+                        pool.install(|| {
+                            post::pow::find_k2_pow(
+                                b"hello world, CHALLENGE me!!!!!!!",
+                                nonce,
+                                ScryptParams::new(6, 0, 0),
+                                threshold,
+                            )
+                        })
+                    },
+                    BatchSize::SmallInput,
+                )
+            },
+        );
+    }
 }
 
 criterion_group!(
     name = benches;
-    config = Criterion::default().with_profiler(PProfProfiler::new(1000, Output::Flamegraph(None)));
+    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
     targets=bench_k2_pow
 );
 

--- a/src/pow.rs
+++ b/src/pow.rs
@@ -5,13 +5,13 @@
 //! with a powerful enough computer could try many nonces
 //! at the same time. In effect a proof could be found
 //! without actually holding the whole POST data.
-use rayon::prelude::*;
+use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 use scrypt_jane::scrypt::{scrypt, ScryptParams};
 
 pub fn find_k2_pow(challenge: &[u8; 32], nonce: u32, params: ScryptParams, difficulty: u64) -> u64 {
     (0u64..u64::MAX)
         .into_par_iter()
-        .find_first(|&k2_pow| hash_k2_pow(challenge, nonce, params, k2_pow) < difficulty)
+        .find_any(|&k2_pow| hash_k2_pow(challenge, nonce, params, k2_pow) < difficulty)
         .expect("looking for k2pow")
 }
 

--- a/tests/generate_and_verify.rs
+++ b/tests/generate_and_verify.rs
@@ -55,7 +55,7 @@ fn test_generate_and_verify() {
 
     // Check that the proof is invalid if we modify one index
     let mut invalid_proof = proof;
-    invalid_proof.indices[0] += 2;
+    invalid_proof.k2_pow = invalid_proof.k2_pow - 1;
     let valid = verify(
         &invalid_proof,
         &metadata,


### PR DESCRIPTION
## root cause
Reason it didn't work: https://github.com/rayon-rs/rayon/issues/908.

TL;DR: rayon's par iter divides the range into equally long blocks and distributes them among threads (block0: [0..X], block1: [X..2X], and so on). It doesn't work optimally with `find_first()` as basically all the work by threads 1..N is wasted.

## Fix
There's no requirement to find the lowest k2 pow nonce value. We only need to find one for which scrypt returns a value < difficulty threshold. Hence it's fine to use `find_any()` and return the first found k2pow nonce (not the smallest one).