### PR TITLE
Mock pow prover in UTs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,6 +717,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -726,6 +732,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "either"
@@ -820,10 +832,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits 0.2.15",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "fragile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "funty"
@@ -1292,6 +1319,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c84490118f2ee2d74570d114f3d0493cbf02790df303d2707606c3e14e07c96"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "nix"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1318,6 +1372,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "num-complex"
@@ -1561,6 +1621,7 @@ dependencies = [
  "eyre",
  "itertools",
  "log",
+ "mockall",
  "pprof",
  "primitive-types",
  "proptest",
@@ -1604,6 +1665,36 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "predicates"
+version = "2.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
+dependencies = [
+ "difflib",
+ "float-cmp",
+ "itertools",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "prettyplease"
@@ -2169,6 +2260,12 @@ checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "textwrap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ randomx-rs = { git = "https://github.com/spacemeshos/randomx-rs", rev = "18080c7
 primitive-types = "0.12.1"
 thiserror = "1.0.40"
 thread_local = "1.1.7"
+mockall = "0.11.4"
 
 [dev-dependencies]
 criterion = "0.4"

--- a/benches/pow.rs
+++ b/benches/pow.rs
@@ -1,6 +1,9 @@
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
 
-use post::pow::randomx::{PoW, RandomXFlag};
+use post::pow::{
+    randomx::{PoW, RandomXFlag},
+    Prover,
+};
 #[cfg(not(windows))]
 use pprof::criterion::{Output, PProfProfiler};
 use rayon::ThreadPoolBuilder;

--- a/src/pow/mod.rs
+++ b/src/pow/mod.rs
@@ -8,7 +8,7 @@
 
 pub mod randomx;
 pub(crate) mod scrypt;
-
+use mockall::*;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -19,4 +19,14 @@ pub enum Error {
     InvalidPoW,
     #[error(transparent)]
     Internal(Box<dyn std::error::Error + Send + Sync>),
+}
+
+#[automock]
+pub trait Prover {
+    fn prove(
+        &self,
+        nonce_group: u8,
+        challenge: &[u8; 8],
+        difficulty: &[u8; 32],
+    ) -> Result<u64, Error>;
 }

--- a/src/prove.rs
+++ b/src/prove.rs
@@ -52,15 +52,10 @@ impl Proof {
 pub struct ProvingParams {
     pub difficulty: u64,
     pub pow_difficulty: [u8; 32],
-    pub pow_flags: RandomXFlag,
 }
 
 impl ProvingParams {
-    pub fn new(
-        metadata: &PostMetadata,
-        cfg: &Config,
-        pow_flags: RandomXFlag,
-    ) -> eyre::Result<Self> {
+    pub fn new(metadata: &PostMetadata, cfg: &Config) -> eyre::Result<Self> {
         let num_labels = metadata.num_units as u64 * metadata.labels_per_unit;
         let mut pow_difficulty = [0u8; 32];
         let difficulty_scaled = U256::from_big_endian(&cfg.pow_difficulty) / metadata.num_units;
@@ -68,7 +63,6 @@ impl ProvingParams {
         Ok(Self {
             difficulty: proving_difficulty(cfg.k1, num_labels)?,
             pow_difficulty,
-            pow_flags,
         })
     }
 }
@@ -99,6 +93,7 @@ fn nonce_group_range(nonces: Range<u32>, per_aes: u32) -> Range<u32> {
     start_group..end_group
 }
 
+#[derive(Debug)]
 pub struct Prover8_56 {
     ciphers: Vec<AesCipher>,
     lazy_ciphers: Vec<AesCipher>,
@@ -109,10 +104,11 @@ pub struct Prover8_56 {
 impl Prover8_56 {
     pub(crate) const NONCES_PER_AES: u32 = 16;
 
-    pub fn new(
+    pub fn new<P: pow::Prover>(
         challenge: &[u8; 32],
         nonces: Range<u32>,
         params: ProvingParams,
+        pow_prover: &P,
     ) -> eyre::Result<Self> {
         // TODO consider to relax it to allow any range of nonces
         eyre::ensure!(
@@ -123,11 +119,7 @@ impl Prover8_56 {
             !nonces.is_empty() && nonces.len() % Self::NONCES_PER_AES as usize == 0,
             "nonces must be a multiple of 16"
         );
-        log::info!(
-            "calculating proof of work for nonces {nonces:?} with PoW flags: {:?}",
-            params.pow_flags
-        );
-        let pow_prover = pow::randomx::PoW::new(params.pow_flags)?;
+        log::info!("calculating proof of work for nonces {nonces:?}",);
         let ciphers: Vec<AesCipher> = nonce_group_range(nonces.clone(), Self::NONCES_PER_AES)
             .map(|nonce_group| {
                 log::debug!("calculating proof of work for nonce group {nonce_group}");
@@ -269,22 +261,29 @@ pub fn generate_proof(
     pow_flags: RandomXFlag,
 ) -> eyre::Result<Proof> {
     let metadata = metadata::load(datadir).wrap_err("loading metadata")?;
-    let params = ProvingParams::new(&metadata, &cfg, pow_flags)?;
+    let params = ProvingParams::new(&metadata, &cfg)?;
+    log::info!("generating proof with PoW flags: {pow_flags:?} and params: {params:?}");
+    let pow_prover = pow::randomx::PoW::new(pow_flags)?;
 
     let mut start_nonce = 0;
     let mut end_nonce = start_nonce + nonces as u32;
 
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(threads)
+        .build()
+        .wrap_err("building thread pool")?;
+
     loop {
         let indexes = Mutex::new(HashMap::<u32, Vec<u64>>::new());
 
-        let pool = rayon::ThreadPoolBuilder::new()
-            .num_threads(threads)
-            .build()
-            .wrap_err("building thread pool")?;
-
         let prover = pool.install(|| {
-            Prover8_56::new(challenge, start_nonce..end_nonce, params.clone())
-                .wrap_err("creating prover")
+            Prover8_56::new(
+                challenge,
+                start_nonce..end_nonce,
+                params.clone(),
+                &pow_prover,
+            )
+            .wrap_err("creating prover")
         })?;
 
         let result = pool.install(|| {
@@ -329,10 +328,10 @@ pub fn generate_proof(
 mod tests {
     use super::*;
     use crate::{compression::decompress_indexes, difficulty::proving_difficulty};
+    use mockall::predicate;
     use rand::{thread_rng, RngCore};
     use scrypt_jane::scrypt::ScryptParams;
     use std::{collections::HashMap, iter::repeat};
-    use RandomXFlag;
 
     #[test]
     fn creating_proof() {
@@ -366,32 +365,59 @@ mod tests {
             pow_difficulty: [0xFF; 32],
             scrypt: ScryptParams::new(1, 0, 0),
         };
-        let pow_flags = RandomXFlag::default();
-        assert!(Prover8_56::new(
-            &[0; 32],
-            0..16,
-            ProvingParams::new(&meta, &cfg, pow_flags).unwrap()
-        )
-        .is_ok());
-        assert!(Prover8_56::new(
-            &[0; 32],
-            16..32,
-            ProvingParams::new(&meta, &cfg, pow_flags).unwrap()
-        )
-        .is_ok());
+        let params = ProvingParams::new(&meta, &cfg).unwrap();
+        let mut pow_prover = pow::MockProver::new();
 
-        assert!(Prover8_56::new(
-            &[0; 32],
-            0..0,
-            ProvingParams::new(&meta, &cfg, pow_flags).unwrap()
-        )
-        .is_err());
-        assert!(Prover8_56::new(
-            &[0; 32],
-            1..16,
-            ProvingParams::new(&meta, &cfg, pow_flags).unwrap()
-        )
-        .is_err());
+        pow_prover
+            .expect_prove()
+            .with(
+                predicate::eq(0),
+                predicate::eq([0; 8]),
+                predicate::eq(cfg.pow_difficulty),
+            )
+            .once()
+            .returning(|_, _, _| Ok(0));
+        assert!(Prover8_56::new(&[0; 32], 0..16, params.clone(), &pow_prover).is_ok());
+
+        pow_prover
+            .expect_prove()
+            .with(
+                predicate::eq(1),
+                predicate::eq([0; 8]),
+                predicate::eq(cfg.pow_difficulty),
+            )
+            .once()
+            .returning(|_, _, _| Ok(0));
+        assert!(Prover8_56::new(&[0; 32], 16..32, params.clone(), &pow_prover).is_ok());
+
+        assert!(Prover8_56::new(&[0; 32], 0..0, params.clone(), &pow_prover).is_err());
+        assert!(Prover8_56::new(&[0; 32], 1..16, params.clone(), &pow_prover).is_err());
+    }
+
+    #[test]
+    fn creating_prover_fails_pow() {
+        let meta = PostMetadata {
+            labels_per_unit: 1000,
+            num_units: 1,
+            max_file_size: 1024,
+            ..Default::default()
+        };
+        let cfg = Config {
+            k1: 279,
+            k2: 300,
+            k3: 65,
+            k2_pow_difficulty: u64::MAX,
+            pow_scrypt: ScryptParams::new(1, 0, 0),
+            pow_difficulty: [0xFF; 32],
+            scrypt: ScryptParams::new(1, 0, 0),
+        };
+        let mut pow_prover = pow::MockProver::new();
+        pow_prover
+            .expect_prove()
+            .once()
+            .returning(|_, _, _| Err(pow::Error::PoWNotFound));
+        let params = ProvingParams::new(&meta, &cfg).unwrap();
+        assert!(Prover8_56::new(&[0; 32], 0..16, params, &pow_prover).is_err());
     }
 
     /// Test that PoW threshold is scaled with num_units.
@@ -415,9 +441,8 @@ mod tests {
             nonce: None,
             last_position: None,
         };
-        let pow_flags = RandomXFlag::default();
         {
-            let params = ProvingParams::new(&metadata, &cfg, pow_flags).unwrap();
+            let params = ProvingParams::new(&metadata, &cfg).unwrap();
             assert_eq!(params.pow_difficulty, cfg.pow_difficulty);
         }
         {
@@ -427,7 +452,6 @@ mod tests {
                     ..metadata
                 },
                 &cfg,
-                pow_flags,
             )
             .unwrap();
             assert!(params.pow_difficulty < cfg.pow_difficulty);
@@ -441,9 +465,17 @@ mod tests {
         let params = ProvingParams {
             difficulty: u64::MAX,
             pow_difficulty: [0xFF; 32],
-            pow_flags: RandomXFlag::get_recommended_flags(),
         };
-        let prover = Prover8_56::new(challenge, 0..Prover8_56::NONCES_PER_AES, params).unwrap();
+        let mut pow_prover = pow::MockProver::new();
+        pow_prover.expect_prove().returning(|_, _, _| Ok(0));
+
+        let prover = Prover8_56::new(
+            challenge,
+            0..Prover8_56::NONCES_PER_AES,
+            params,
+            &pow_prover,
+        )
+        .unwrap();
         let res = prover.prove(&[0u8; 8 * LABEL_SIZE], 0, |nonce, index| {
             let _ = tx.send((nonce, index));
             None
@@ -476,14 +508,20 @@ mod tests {
         let params = ProvingParams {
             difficulty: proving_difficulty(K1, NUM_LABELS as u64).unwrap(),
             pow_difficulty: [0xFF; 32],
-            pow_flags: RandomXFlag::get_recommended_flags(),
         };
+        let mut pow_prover = pow::MockProver::new();
+        pow_prover.expect_prove().returning(|_, _, _| Ok(0));
 
         let indexes = loop {
             let mut indicies = HashMap::<u32, Vec<u64>>::new();
 
-            let prover =
-                Prover8_56::new(challenge, start_nonce..end_nonce, params.clone()).unwrap();
+            let prover = Prover8_56::new(
+                challenge,
+                start_nonce..end_nonce,
+                params.clone(),
+                &pow_prover,
+            )
+            .unwrap();
 
             let result = prover.prove(&data, 0, |nonce, index| {
                 let vec = indicies.entry(nonce).or_default();
@@ -533,14 +571,21 @@ mod tests {
         let params = ProvingParams {
             difficulty: proving_difficulty(k1, num_labels as u64).unwrap(),
             pow_difficulty: [0xFF; 32],
-            pow_flags: RandomXFlag::get_recommended_flags(),
         };
+        let mut pow_prover = pow::MockProver::new();
+        pow_prover.expect_prove().once().returning(|_, _, _| Ok(0));
         let data = repeat(0..=11) // it's important for range len to not be a multiple of AES block
             .flatten()
             .take(num_labels * LABEL_SIZE)
             .collect::<Vec<u8>>();
 
-        let prover = Prover8_56::new(challenge, 0..Prover8_56::NONCES_PER_AES, params).unwrap();
+        let prover = Prover8_56::new(
+            challenge,
+            0..Prover8_56::NONCES_PER_AES,
+            params,
+            &pow_prover,
+        )
+        .unwrap();
 
         let mut indexes = HashMap::<u32, Vec<u64>>::new();
 

--- a/src/prove.rs
+++ b/src/prove.rs
@@ -328,7 +328,7 @@ pub fn generate_proof(
 mod tests {
     use super::*;
     use crate::{compression::decompress_indexes, difficulty::proving_difficulty};
-    use mockall::predicate;
+    use mockall::predicate::eq;
     use rand::{thread_rng, RngCore};
     use scrypt_jane::scrypt::ScryptParams;
     use std::{collections::HashMap, iter::repeat};
@@ -370,22 +370,14 @@ mod tests {
 
         pow_prover
             .expect_prove()
-            .with(
-                predicate::eq(0),
-                predicate::eq([0; 8]),
-                predicate::eq(cfg.pow_difficulty),
-            )
+            .with(eq(0), eq([0; 8]), eq(cfg.pow_difficulty))
             .once()
             .returning(|_, _, _| Ok(0));
         assert!(Prover8_56::new(&[0; 32], 0..16, params.clone(), &pow_prover).is_ok());
 
         pow_prover
             .expect_prove()
-            .with(
-                predicate::eq(1),
-                predicate::eq([0; 8]),
-                predicate::eq(cfg.pow_difficulty),
-            )
+            .with(eq(1), eq([0; 8]), eq(cfg.pow_difficulty))
             .once()
             .returning(|_, _, _| Ok(0));
         assert!(Prover8_56::new(&[0; 32], 16..32, params.clone(), &pow_prover).is_ok());

--- a/src/verification.rs
+++ b/src/verification.rs
@@ -236,7 +236,10 @@ mod tests {
     use crate::{
         config::Config,
         metadata::ProofMetadata,
-        pow::randomx::{PoW, RandomXFlag},
+        pow::{
+            randomx::{PoW, RandomXFlag},
+            Prover,
+        },
         prove::Proof,
     };
 


### PR DESCRIPTION
Added a proof of work `Prover` trait for easier (and faster) testing of proof generating by injecting mock prover. It also allows covering  unhappy-path in PoW.