### PR TITLE
Fix clippy warning about unused Box::from_raw result

### DIFF
--- a/ffi/src/initialization.rs
+++ b/ffi/src/initialization.rs
@@ -202,7 +202,7 @@ fn _new_initializer(
 
 #[no_mangle]
 pub extern "C" fn free_initializer(initializer: *mut Initializer) {
-    unsafe { Box::from_raw(initializer as *mut InitializerWrapper) };
+    unsafe { drop(Box::from_raw(initializer as *mut InitializerWrapper)) };
 }
 
 #[cfg(test)]

--- a/ffi/src/post_impl.rs
+++ b/ffi/src/post_impl.rs
@@ -139,7 +139,7 @@ pub extern "C" fn free_verifier(verifier: *mut Verifier) {
     if verifier.is_null() {
         return;
     }
-    unsafe { Box::from_raw(verifier) };
+    unsafe { drop(Box::from_raw(verifier)) };
 }
 
 /// Verify a proof


### PR DESCRIPTION
Fixes:
```
[unused return value of `std::boxed::Box::<T>::from_raw` that must be used: ffi/src/post_impl.rs#L142](https://github.com/spacemeshos/post-rs/commit/357757e60e2f4a6d35e093371c151e421b3c5f8e#annotation_12163404569)
warning: unused return value of `std::boxed::Box::<T>::from_raw` that must be used
   --> ffi/src/post_impl.rs:142:14
    |
142 |     unsafe { Box::from_raw(verifier) };
    |              ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: call `drop(Box::from_raw(ptr))` if you intend to drop the `Box`
help: use `let _ = ...` to ignore the resulting value
    |
142 |     unsafe { let _ = Box::from_raw(verifier); };
    |              +++++++                        +
```