### PR TITLE
Allow blacklisting OCL platforms and providers via a regex in ENV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,10 @@ jobs:
             toolchain: stable
           - os: [self-hosted, linux, arm64]
             rustflags: --cfg=aes_armv8
-            toolchain: nightly # required for AES (https://docs.rs/aes/0.8.2/aes/#armv8-intrinsics-nightly-only)
+            toolchain: nightly-2023-06-27 # required for AES (https://docs.rs/aes/0.8.2/aes/#armv8-intrinsics-nightly-only)
           - os: [self-hosted, macos, arm64]
             rustflags: --cfg=aes_armv8
-            toolchain: nightly # required for AES (https://docs.rs/aes/0.8.2/aes/#armv8-intrinsics-nightly-only)
+            toolchain: nightly-2023-06-27 # required for AES (https://docs.rs/aes/0.8.2/aes/#armv8-intrinsics-nightly-only)
           - os: macos-latest
             toolchain: stable
           - os: windows-2019
@@ -90,9 +90,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@master
         with:
           components: clippy
+          toolchain: nightly-2023-06-27
       - uses: Swatinem/rust-cache@v2
       - name: Annotate commit with clippy warnings
         uses: actions-rs/clippy-check@v1
@@ -142,14 +143,14 @@ jobs:
             staticlib: libpost.a
             rustflags: --cfg=aes_armv8
             artifact-name: linux-arm64
-            toolchain: nightly # required for AES (https://docs.rs/aes/0.8.2/aes/#armv8-intrinsics-nightly-only)
+            toolchain: nightly-2023-06-27 # required for AES (https://docs.rs/aes/0.8.2/aes/#armv8-intrinsics-nightly-only)
 
           - os: [self-hosted, macos, arm64]
             dylib: libpost.dylib
             staticlib: libpost.a
             rustflags: --cfg=aes_armv8
             artifact-name: macos-m1
-            toolchain: nightly # required for AES (https://docs.rs/aes/0.8.2/aes/#armv8-intrinsics-nightly-only)
+            toolchain: nightly-2023-06-27 # required for AES (https://docs.rs/aes/0.8.2/aes/#armv8-intrinsics-nightly-only)
 
           - os: macos-latest
             dylib: libpost.dylib

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1907,13 +1907,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.1"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.1",
+ "regex-syntax 0.7.2",
 ]
 
 [[package]]
@@ -1924,9 +1924,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "rgb"
@@ -2068,6 +2068,7 @@ dependencies = [
  "log",
  "ocl",
  "post-rs",
+ "regex",
  "rstest",
  "thiserror",
 ]

--- a/scrypt-ocl/Cargo.toml
+++ b/scrypt-ocl/Cargo.toml
@@ -8,6 +8,7 @@ ocl = "0.19.4"
 thiserror = "1.0.40"
 post-rs = { path = "../" }
 log = "0.4.17"
+regex = "1.8.4"
 
 [dev-dependencies]
 post-rs = { path = "../" }

--- a/scrypt-ocl/src/filtering.rs
+++ b/scrypt-ocl/src/filtering.rs
@@ -1,0 +1,74 @@
+use regex::Regex;
+
+const PLATFORMS_BLACKLIST_ENV: &str = "POST_OCL_PLATFORMS_BLACKLIST";
+const DEVICES_BLACKLIST_ENV: &str = "POST_OCL_DEVICES_BLACKLIST";
+
+fn create_blacklist_filter(blacklist_re: Option<&str>) -> Box<dyn Fn(&str) -> bool> {
+    blacklist_re
+        .and_then(|re| -> Option<Box<dyn Fn(&str) -> bool>> {
+            match Regex::new(re) {
+                Ok(re) => Some(Box::new(move |name| !re.is_match(name))),
+                Err(e) => {
+                    log::warn!("Invalid blacklist regex: ({e})");
+                    None
+                }
+            }
+        })
+        .unwrap_or(Box::new(|_| true))
+}
+
+pub(crate) fn create_platform_filter() -> Box<dyn Fn(&str) -> bool> {
+    create_blacklist_filter(std::env::var(PLATFORMS_BLACKLIST_ENV).ok().as_deref())
+}
+
+pub(crate) fn create_device_filter() -> Box<dyn Fn(&str) -> bool> {
+    create_blacklist_filter(std::env::var(DEVICES_BLACKLIST_ENV).ok().as_deref())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_create_filter() {
+        let filter = super::create_blacklist_filter(Some("foo"));
+        assert_eq!(filter("foo"), false);
+        assert_eq!(filter("bar"), true);
+        assert_eq!(filter(""), true);
+    }
+
+    #[test]
+    fn test_regex_filter() {
+        let filter = super::create_blacklist_filter(Some("foo|bar"));
+        assert_eq!(filter("foo"), false);
+        assert_eq!(filter("bar"), false);
+        assert_eq!(filter("baz"), true);
+    }
+
+    #[test]
+    fn test_invalid_regex_filter() {
+        let filter = super::create_blacklist_filter(Some("fo(o"));
+        assert_eq!(filter("foo"), true);
+        assert_eq!(filter("bar"), true);
+    }
+
+    #[test]
+    fn test_device_filter_env_not_set() {
+        let filter = super::create_device_filter();
+        assert_eq!(filter("foo"), true);
+    }
+
+    #[test]
+    fn test_device_filter_env_set() {
+        std::env::set_var(super::DEVICES_BLACKLIST_ENV, "foo");
+        let filter = super::create_device_filter();
+        assert_eq!(filter("foo"), false);
+        assert_eq!(filter("bar"), true);
+    }
+
+    #[test]
+    fn test_platform_filter_env_set() {
+        std::env::set_var(super::PLATFORMS_BLACKLIST_ENV, "foo");
+        let filter = super::create_platform_filter();
+        assert_eq!(filter("foo"), false);
+        assert_eq!(filter("bar"), true);
+    }
+}

--- a/scrypt-ocl/src/filtering.rs
+++ b/scrypt-ocl/src/filtering.rs
@@ -4,17 +4,19 @@ const PLATFORMS_BLACKLIST_ENV: &str = "POST_OCL_PLATFORMS_BLACKLIST";
 const DEVICES_BLACKLIST_ENV: &str = "POST_OCL_DEVICES_BLACKLIST";
 
 fn create_blacklist_filter(blacklist_re: Option<&str>) -> Box<dyn Fn(&str) -> bool> {
-    blacklist_re
-        .and_then(|re| -> Option<Box<dyn Fn(&str) -> bool>> {
-            match Regex::new(re) {
-                Ok(re) => Some(Box::new(move |name| !re.is_match(name))),
-                Err(e) => {
-                    log::warn!("Invalid blacklist regex: ({e})");
-                    None
-                }
-            }
-        })
-        .unwrap_or(Box::new(|_| true))
+    let Some(blacklist_re) = blacklist_re else {
+        return Box::new(|_|  true );
+    };
+    match Regex::new(blacklist_re) {
+        Ok(re) => {
+            log::debug!("Using blacklist filter: {}", blacklist_re);
+            Box::new(move |name: &str| !re.is_match(name))
+        }
+        Err(e) => {
+            log::error!("Invalid blacklist filter: {}", e);
+            Box::new(|_| true)
+        }
+    }
 }
 
 pub(crate) fn create_platform_filter() -> Box<dyn Fn(&str) -> bool> {
@@ -30,45 +32,39 @@ mod tests {
     #[test]
     fn test_create_filter() {
         let filter = super::create_blacklist_filter(Some("foo"));
-        assert_eq!(filter("foo"), false);
-        assert_eq!(filter("bar"), true);
-        assert_eq!(filter(""), true);
+
+        assert!(!filter("foo"));
+        assert!(filter("bar"));
+        assert!(filter(""));
     }
 
     #[test]
     fn test_regex_filter() {
         let filter = super::create_blacklist_filter(Some("foo|bar"));
-        assert_eq!(filter("foo"), false);
-        assert_eq!(filter("bar"), false);
-        assert_eq!(filter("baz"), true);
+        assert!(!filter("foo"));
+        assert!(!filter("bar"));
+        assert!(filter("baz"));
     }
 
     #[test]
     fn test_invalid_regex_filter() {
         let filter = super::create_blacklist_filter(Some("fo(o"));
-        assert_eq!(filter("foo"), true);
-        assert_eq!(filter("bar"), true);
-    }
-
-    #[test]
-    fn test_device_filter_env_not_set() {
-        let filter = super::create_device_filter();
-        assert_eq!(filter("foo"), true);
+        assert!(filter("foo"));
     }
 
     #[test]
     fn test_device_filter_env_set() {
         std::env::set_var(super::DEVICES_BLACKLIST_ENV, "foo");
         let filter = super::create_device_filter();
-        assert_eq!(filter("foo"), false);
-        assert_eq!(filter("bar"), true);
+        assert!(!filter("foo"));
+        assert!(filter("bar"));
     }
 
     #[test]
     fn test_platform_filter_env_set() {
         std::env::set_var(super::PLATFORMS_BLACKLIST_ENV, "foo");
         let filter = super::create_platform_filter();
-        assert_eq!(filter("foo"), false);
-        assert_eq!(filter("bar"), true);
+        assert!(!filter("foo"));
+        assert!(filter("bar"));
     }
 }

--- a/src/prove.rs
+++ b/src/prove.rs
@@ -374,7 +374,7 @@ mod tests {
         assert!(Prover8_56::new(&[0; 32], 16..32, params.clone(), &pow_prover).is_ok());
 
         assert!(Prover8_56::new(&[0; 32], 0..0, params.clone(), &pow_prover).is_err());
-        assert!(Prover8_56::new(&[0; 32], 1..16, params.clone(), &pow_prover).is_err());
+        assert!(Prover8_56::new(&[0; 32], 1..16, params, &pow_prover).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Reasoning
For some users, a Microsoft Basic Renderer openCL provider shows up which misbehaves (a crash in the opencl.dll with C000...5). This PR brings a flexible solution to easily skip certain openCL platforms and devices

Users can configure blacklists via two environment variables
- POST_OCL_PLATFORMS_BLACKLIST
- POST_OCL_DEVICES_BLACKLIST

Both accept a regex for flexibility.