### PR TITLE
Make sure profiler reads from disk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,7 +188,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.15",
+ "syn 2.0.23",
  "which",
 ]
 
@@ -445,7 +445,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -613,31 +613,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossterm"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
-dependencies = [
- "bitflags",
- "crossterm_winapi",
- "libc",
- "mio",
- "parking_lot",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,7 +652,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.15",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -694,7 +669,7 @@ checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -763,12 +738,6 @@ name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
-
-[[package]]
-name = "dyn-clone"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 
 [[package]]
 name = "either"
@@ -951,7 +920,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -1187,22 +1156,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inquire"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33e7c1ddeb15c9abcbfef6029d8e29f69b52b6d6c891031b88ed91b5065803b"
-dependencies = [
- "bitflags",
- "crossterm",
- "dyn-clone",
- "lazy_static",
- "newline-converter",
- "thiserror",
- "unicode-segmentation",
- "unicode-width",
-]
-
-[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1319,12 +1272,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "memchr"
@@ -1366,18 +1316,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
-dependencies = [
- "libc",
- "log",
- "wasi",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "mockall"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1402,15 +1340,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "newline-converter"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f71d09d5c87634207f894c6b31b6a2b2c64ea3bdcf71bd5599fdbbe1600c00f"
-dependencies = [
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -1771,7 +1700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ceca8aaf45b5c46ec7ed39fff75f57290368c1846d33d24a122ca81416ab058"
 dependencies = [
  "proc-macro2",
- "syn 2.0.15",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -1797,9 +1726,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]
@@ -1811,12 +1740,13 @@ dependencies = [
  "clap 4.2.4",
  "env_logger",
  "eyre",
- "inquire",
+ "libc",
  "post-rs",
  "rand",
  "rayon",
  "serde",
  "serde_json",
+ "windows",
 ]
 
 [[package]]
@@ -1863,9 +1793,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
@@ -1928,7 +1858,6 @@ dependencies = [
 [[package]]
 name = "randomx-rs"
 version = "1.1.15"
-source = "git+https://github.com/spacemeshos/randomx-rs?rev=18080c74da8b179a2e99d2eef4e0c0279fd6f75a#18080c74da8b179a2e99d2eef4e0c0279fd6f75a"
 dependencies = [
  "bitflags",
  "libc",
@@ -2165,7 +2094,7 @@ checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -2212,36 +2141,6 @@ name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
-
-[[package]]
-name = "signal-hook"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook-mio"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
-dependencies = [
- "libc",
- "mio",
- "signal-hook",
-]
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "slab"
@@ -2324,9 +2223,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.15"
+version = "2.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2375,22 +2274,22 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "c16a64ba9387ef3fdae4f9c1a7f07a0997fce91985c0336f1ddc1822b3b37802"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "d14928354b01c4d6a4f0e549069adef399a284e7995c7ccca94e8a07a5346c59"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -2495,12 +2394,6 @@ name = "unicode-ident"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,6 +613,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossterm"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,6 +763,12 @@ name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 
 [[package]]
 name = "either"
@@ -1156,6 +1187,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "inquire"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33e7c1ddeb15c9abcbfef6029d8e29f69b52b6d6c891031b88ed91b5065803b"
+dependencies = [
+ "bitflags",
+ "crossterm",
+ "dyn-clone",
+ "lazy_static",
+ "newline-converter",
+ "thiserror",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1225,9 +1272,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.142"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libloading"
@@ -1319,6 +1366,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "mockall"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1343,6 +1402,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "newline-converter"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f71d09d5c87634207f894c6b31b6a2b2c64ea3bdcf71bd5599fdbbe1600c00f"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1743,7 +1811,9 @@ dependencies = [
  "clap 4.2.4",
  "env_logger",
  "eyre",
+ "inquire",
  "post-rs",
+ "rand",
  "rayon",
  "serde",
  "serde_json",
@@ -2144,6 +2214,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2395,6 +2495,12 @@ name = "unicode-ident"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1858,6 +1858,7 @@ dependencies = [
 [[package]]
 name = "randomx-rs"
 version = "1.1.15"
+source = "git+https://github.com/spacemeshos/randomx-rs?rev=18080c74da8b179a2e99d2eef4e0c0279fd6f75a#18080c74da8b179a2e99d2eef4e0c0279fd6f75a"
 dependencies = [
  "bitflags",
  "libc",

--- a/profiler/Cargo.toml
+++ b/profiler/Cargo.toml
@@ -7,7 +7,9 @@ edition = "2021"
 clap = { version = "4.1.11", features = ["derive"] }
 env_logger = "0.10.0"
 eyre = "0.6.8"
+inquire = "0.6.2"
 post-rs = { path = "../" }
+rand = "0.8.5"
 rayon = "1.7.0"
 serde = { version = "1.0.158", features = ["derive"] }
 serde_json = "1.0.94"

--- a/profiler/Cargo.toml
+++ b/profiler/Cargo.toml
@@ -7,9 +7,15 @@ edition = "2021"
 clap = { version = "4.1.11", features = ["derive"] }
 env_logger = "0.10.0"
 eyre = "0.6.8"
-inquire = "0.6.2"
+libc = "0.2.146"
 post-rs = { path = "../" }
 rand = "0.8.5"
 rayon = "1.7.0"
 serde = { version = "1.0.158", features = ["derive"] }
 serde_json = "1.0.94"
+
+windows = { version = "0.48", features = [
+    "Win32_Foundation",
+    "Win32_Storage_FileSystem",
+    "Win32_Security",
+] }

--- a/profiler/src/main.rs
+++ b/profiler/src/main.rs
@@ -87,9 +87,9 @@ fn prepare_data_file(path: &Path, size: u64) -> eyre::Result<()> {
 
         while remaining_to_write > 0 {
             let to_write = min(buf.len() as u64, remaining_to_write);
-            let mut buf = &mut buf[..to_write as usize];
-            rng.fill_bytes(&mut buf);
-            f.write_all(&buf)?;
+            let buf = &mut buf[..to_write as usize];
+            rng.fill_bytes(buf);
+            f.write_all(buf)?;
             remaining_to_write -= to_write;
         }
     }
@@ -112,8 +112,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let pool = rayon::ThreadPoolBuilder::new()
         .num_threads(args.threads)
-        .build()
-        .unwrap();
+        .build()?;
     let mut pow_prover = pow::MockProver::new();
     pow_prover.expect_prove().returning(|_, _, _| Ok(0));
     let prover = Prover8_56::new(challenge, 0..args.nonces, params, &pow_prover)?;
@@ -142,7 +141,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         time_s: elapsed.as_secs_f64(),
         speed_gib_s: iterations as f64 * args.data_size as f64 / elapsed.as_secs_f64(),
     };
-    println!("{}", serde_json::to_string_pretty(&result).unwrap());
+    println!("{}", serde_json::to_string_pretty(&result)?);
 
     Ok(())
 }

--- a/profiler/src/util/linux.rs
+++ b/profiler/src/util/linux.rs
@@ -1,4 +1,4 @@
-use std::{error::Error, fs::File, fs::OpenOptions, os::fd::AsRawFd, path::Path};
+use std::{error::Error, fs::File, os::fd::AsRawFd, path::Path};
 
 pub(crate) fn open_without_cache(path: &Path) -> Result<File, Box<dyn Error>> {
     let file = File::open(path)?;

--- a/profiler/src/util/linux.rs
+++ b/profiler/src/util/linux.rs
@@ -1,0 +1,19 @@
+use std::{error::Error, fs::File, fs::OpenOptions, os::fd::AsRawFd, path::Path};
+
+pub(crate) fn open_without_cache(path: &Path) -> Result<File, Box<dyn Error>> {
+    let file = File::open(path)?;
+
+    let ret = unsafe {
+        libc::posix_fadvise(
+            file.as_raw_fd(),
+            0 as libc::off_t,
+            0 as libc::off_t,
+            libc::POSIX_FADV_DONTNEED,
+        )
+    };
+    if ret != 0 {
+        return Err(format!("posix_fadvise failed: {ret}").into());
+    }
+
+    Ok(file)
+}

--- a/profiler/src/util/linux.rs
+++ b/profiler/src/util/linux.rs
@@ -1,6 +1,6 @@
-use std::{error::Error, fs::File, os::fd::AsRawFd, path::Path};
+use std::{fs::File, os::fd::AsRawFd, path::Path};
 
-pub(crate) fn open_without_cache(path: &Path) -> Result<File, Box<dyn Error>> {
+pub(crate) fn open_without_cache(path: &Path) -> eyre::Result<File> {
     let file = File::open(path)?;
 
     let ret = unsafe {
@@ -11,9 +11,7 @@ pub(crate) fn open_without_cache(path: &Path) -> Result<File, Box<dyn Error>> {
             libc::POSIX_FADV_DONTNEED,
         )
     };
-    if ret != 0 {
-        return Err(format!("posix_fadvise failed: {ret}").into());
-    }
+    eyre::ensure!(ret == 0, format!("posix_fadvise failed: {ret}"));
 
     Ok(file)
 }

--- a/profiler/src/util/macos.rs
+++ b/profiler/src/util/macos.rs
@@ -1,0 +1,6 @@
+use std::{error::Error, fs::File, path::Path};
+
+pub(crate) fn open_without_cache(path: &Path) -> Result<File, Box<dyn Error>> {
+    let file = File::open(path)?;
+    Ok(file)
+}

--- a/profiler/src/util/macos.rs
+++ b/profiler/src/util/macos.rs
@@ -1,6 +1,10 @@
-use std::{error::Error, fs::File, path::Path};
+use std::{fs::File, os::fd::AsRawFd, path::Path};
 
-pub(crate) fn open_without_cache(path: &Path) -> Result<File, Box<dyn Error>> {
+pub(crate) fn open_without_cache(path: &Path) -> eyre::Result<File> {
     let file = File::open(path)?;
+
+    let ret = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_NOCACHE, 1 as libc::c_int) };
+    eyre::ensure!(ret == 0, format!("fcntl(F_NOCACHE) failed: {ret}"));
+
     Ok(file)
 }

--- a/profiler/src/util/mod.rs
+++ b/profiler/src/util/mod.rs
@@ -1,0 +1,9 @@
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "linux")]
+pub(crate) use linux::*;
+
+#[cfg(target_os = "windows")]
+mod windows;
+#[cfg(target_os = "windows")]
+pub(crate) use self::windows::*;

--- a/profiler/src/util/mod.rs
+++ b/profiler/src/util/mod.rs
@@ -7,3 +7,8 @@ pub(crate) use linux::*;
 mod windows;
 #[cfg(target_os = "windows")]
 pub(crate) use self::windows::*;
+
+#[cfg(target_os = "macos")]
+mod macos;
+#[cfg(target_os = "macos")]
+pub(crate) use self::macos::*;

--- a/profiler/src/util/windows.rs
+++ b/profiler/src/util/windows.rs
@@ -1,0 +1,33 @@
+use std::{error::Error, ffi::CString, fs::File, path::Path};
+
+use windows::{
+    core::PCSTR,
+    Win32::{
+        Foundation::{CloseHandle, FALSE, GENERIC_READ, HANDLE},
+        Storage::FileSystem::{
+            CreateFileA, FILE_FLAG_NO_BUFFERING, FILE_SHARE_READ, OPEN_EXISTING,
+        },
+    },
+};
+
+pub(crate) fn open_without_cache(path: &Path) -> Result<File, Box<dyn Error>> {
+    let p = CString::new(path.to_str().ok_or("invalid path")?)?;
+    let handle = unsafe {
+        CreateFileA(
+            PCSTR(p.as_ptr() as _),
+            GENERIC_READ.0,
+            FILE_SHARE_READ,
+            None,
+            OPEN_EXISTING,
+            FILE_FLAG_NO_BUFFERING, // <- drops cache
+            HANDLE(0),
+        )
+    }?;
+
+    if unsafe { CloseHandle(handle) } == FALSE {
+        return Err("failed to close file handle".into());
+    }
+
+    let f = File::open(path)?;
+    Ok(f)
+}


### PR DESCRIPTION
Closes #102

What changed:
- the data file is filled with random data instead of zeros,
- file cache is dropped before reading the file on every iteration (each iter reads the whole file from the beginning to the end),
- fixed the default data file location for windows (it used to be /tmp/data.bin).