### PR TITLE
Miner ID in k2 pow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,11 +69,17 @@ jobs:
         run: cargo test -p scrypt-ocl --all-features --release -- --test-threads=1
         env:
           RUSTFLAGS: ${{ matrix.rustflags }}
+          # https://github.com/tevador/RandomX/issues/262
+          # https://github.com/tari-project/randomx-rs/issues/48
+          SDKROOT: "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk"
 
       - name: Test ffi crate
         run: cargo test -p post-cbindings --all-features --release -- --test-threads=1
         env:
           RUSTFLAGS: ${{ matrix.rustflags }}
+          # https://github.com/tevador/RandomX/issues/262
+          # https://github.com/tari-project/randomx-rs/issues/48
+          SDKROOT: "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk"
 
   fmt:
     name: Rustfmt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1606,6 +1606,7 @@ dependencies = [
  "log",
  "post-rs",
  "scrypt-ocl",
+ "tempfile",
 ]
 
 [[package]]
@@ -2241,15 +2242,16 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
 dependencies = [
+ "autocfg",
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
  "rustix",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/benches/pow.rs
+++ b/benches/pow.rs
@@ -30,7 +30,9 @@ fn bench_pow(c: &mut Criterion) {
             |b| {
                 b.iter_batched(
                     rand::random,
-                    |nonce| pool.install(|| prover.prove(nonce, b"challeng", difficulty).unwrap()),
+                    |nonce| {
+                        pool.install(|| prover.prove(nonce, b"challeng", difficulty, None).unwrap())
+                    },
                     BatchSize::SmallInput,
                 )
             },
@@ -45,7 +47,9 @@ fn verify_pow_light_stateless(c: &mut Criterion) {
             rand::random,
             |pow| {
                 let prover = PoW::new(flags).unwrap();
-                prover.verify(pow, 7, b"challeng", &[0xFFu8; 32]).unwrap();
+                prover
+                    .verify(pow, 7, b"challeng", &[0xFFu8; 32], None)
+                    .unwrap();
             },
             BatchSize::SmallInput,
         )
@@ -60,7 +64,9 @@ fn verify_pow_light(c: &mut Criterion) {
         b.iter_batched(
             rand::random,
             |pow| {
-                prover.verify(pow, 7, b"challeng", &[0xFFu8; 32]).unwrap();
+                prover
+                    .verify(pow, 7, b"challeng", &[0xFFu8; 32], None)
+                    .unwrap();
             },
             BatchSize::SmallInput,
         )
@@ -75,7 +81,9 @@ fn verify_pow_fast(c: &mut Criterion) {
         b.iter_batched(
             rand::random,
             |pow| {
-                prover.verify(pow, 7, b"challeng", &[0xFFu8; 32]).unwrap();
+                prover
+                    .verify(pow, 7, b"challeng", &[0xFFu8; 32], None)
+                    .unwrap();
             },
             BatchSize::SmallInput,
         )

--- a/benches/proving.rs
+++ b/benches/proving.rs
@@ -48,9 +48,10 @@ fn prover_bench(c: &mut Criterion) {
                 pow_prover
                     .expect_prove()
                     .times(nonces as usize / 16)
-                    .returning(|_, _, _| Ok(0));
+                    .returning(|_, _, _, _| Ok(0));
                 let prover =
-                    Prover8_56::new(CHALLENGE, 0..nonces, params.clone(), &pow_prover).unwrap();
+                    Prover8_56::new(CHALLENGE, 0..nonces, params.clone(), &pow_prover, None)
+                        .unwrap();
                 b.iter(|| {
                     let f = black_box(|_, _| None);
                     match threads {

--- a/benches/verifying.rs
+++ b/benches/verifying.rs
@@ -31,6 +31,7 @@ fn verifying(c: &mut Criterion) {
         (0..k2 as u64).collect::<Vec<u64>>().as_slice(),
         num_labels,
         0,
+        None,
     );
     let params = VerifyingParams {
         difficulty: u64::MAX,

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -15,3 +15,6 @@ scrypt-ocl = { path = "../scrypt-ocl" }
 
 [build-dependencies]
 cbindgen = "*"
+
+[dev-dependencies]
+tempfile = "3.6.0"

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -3,9 +3,19 @@ mod log;
 mod post_impl;
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct ArrayU8 {
     ptr: *mut u8,
     len: usize,
     cap: usize,
+}
+
+impl Default for ArrayU8 {
+    fn default() -> Self {
+        Self {
+            ptr: std::ptr::null_mut(),
+            len: 0,
+            cap: 0,
+        }
+    }
 }

--- a/ffi/src/post_impl.rs
+++ b/ffi/src/post_impl.rs
@@ -19,22 +19,61 @@ use post::{
 use crate::ArrayU8;
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct Proof {
     nonce: u32,
     indices: ArrayU8,
     pow: u64,
+    pow_creator: ArrayU8,
 }
 
-impl<'a> From<prove::Proof<'a>> for Proof {
-    fn from(proof: prove::Proof<'a>) -> Self {
+impl From<prove::Proof<'_, '_>> for Proof {
+    fn from(proof: prove::Proof<'_, '_>) -> Self {
         let mut indices = ManuallyDrop::new(proof.indices.into_owned());
         let (ptr, len, cap) = (indices.as_mut_ptr(), indices.len(), indices.capacity());
+
+        let pow_creator = proof
+            .pow_creator
+            .map(|creator| {
+                // make a copy of the creator
+                let mut creator = ManuallyDrop::new(creator.to_vec());
+                let (ptr, len, cap) = (creator.as_mut_ptr(), creator.len(), creator.capacity());
+                ArrayU8 { ptr, len, cap }
+            })
+            .unwrap_or_default();
+
         Self {
             nonce: proof.nonce,
             indices: ArrayU8 { ptr, len, cap },
             pow: proof.pow,
+            pow_creator,
         }
+    }
+}
+
+impl TryInto<prove::Proof<'_, '_>> for Proof {
+    type Error = Box<dyn Error>;
+
+    fn try_into(self) -> Result<prove::Proof<'static, 'static>, Self::Error> {
+        let indices = unsafe { slice::from_raw_parts(self.indices.ptr, self.indices.len) };
+        let pow_creator = if self.pow_creator.ptr.is_null() {
+            None
+        } else {
+            if self.pow_creator.len != 32 {
+                return Err(
+                    format!("Invalid pow_creator length ({})", self.pow_creator.len).into(),
+                );
+            }
+            let pow_creator_slice =
+                unsafe { slice::from_raw_parts(self.pow_creator.ptr, self.pow_creator.len) };
+            Some(pow_creator_slice.try_into().unwrap())
+        };
+        Ok(post::prove::Proof {
+            nonce: self.nonce,
+            indices: Cow::from(indices),
+            pow: self.pow,
+            pow_creator,
+        })
     }
 }
 
@@ -44,7 +83,16 @@ impl<'a> From<prove::Proof<'a>> for Proof {
 #[no_mangle]
 pub unsafe extern "C" fn free_proof(proof: *mut Proof) {
     let proof = Box::from_raw(proof);
-    Vec::from_raw_parts(proof.indices.ptr, proof.indices.len, proof.indices.cap);
+    if !proof.indices.ptr.is_null() {
+        Vec::from_raw_parts(proof.indices.ptr, proof.indices.len, proof.indices.cap);
+    }
+    if !proof.pow_creator.ptr.is_null() {
+        Vec::from_raw_parts(
+            proof.pow_creator.ptr,
+            proof.pow_creator.len,
+            proof.pow_creator.cap,
+        );
+    }
     // proof and vec will be deallocated on return
 }
 
@@ -53,6 +101,7 @@ pub unsafe extern "C" fn free_proof(proof: *mut Proof) {
 /// If an error occurs, prints it on stderr and returns null.
 /// # Safety
 /// `challenge` must be a 32-byte array.
+/// `miner_id` must be null or point to a 32-byte array.
 #[no_mangle]
 pub extern "C" fn generate_proof(
     datadir: *const c_char,
@@ -61,8 +110,11 @@ pub extern "C" fn generate_proof(
     nonces: usize,
     threads: usize,
     pow_flags: RandomXFlag,
+    miner_id: *const c_uchar,
 ) -> *mut Proof {
-    match _generate_proof(datadir, challenge, cfg, nonces, threads, pow_flags) {
+    match _generate_proof(
+        datadir, challenge, cfg, nonces, threads, pow_flags, miner_id,
+    ) {
         Ok(proof) => Box::into_raw(proof),
         Err(e) => {
             //TODO(poszu) communicate errors better
@@ -79,6 +131,7 @@ fn _generate_proof(
     nonces: usize,
     threads: usize,
     pow_flags: RandomXFlag,
+    miner_id: *const c_uchar,
 ) -> Result<Box<Proof>, Box<dyn Error>> {
     let datadir = unsafe { CStr::from_ptr(datadir) };
     let datadir = Path::new(
@@ -90,7 +143,16 @@ fn _generate_proof(
     let challenge = unsafe { std::slice::from_raw_parts(challenge, 32) };
     let challenge = challenge.try_into()?;
 
-    let proof = prove::generate_proof(datadir, challenge, cfg, nonces, threads, pow_flags)?;
+    let miner_id = if miner_id.is_null() {
+        None
+    } else {
+        let miner_id = unsafe { std::slice::from_raw_parts(miner_id, 32) };
+        Some(miner_id.try_into().unwrap())
+    };
+
+    let proof = prove::generate_proof(
+        datadir, challenge, cfg, nonces, threads, pow_flags, miner_id,
+    )?;
     Ok(Box::new(Proof::from(proof)))
 }
 
@@ -161,12 +223,11 @@ pub unsafe extern "C" fn verify_proof(
         }
     };
 
-    let proof = {
-        let indices = unsafe { slice::from_raw_parts(proof.indices.ptr, proof.indices.len) };
-        post::prove::Proof {
-            nonce: proof.nonce,
-            indices: Cow::from(indices),
-            pow: proof.pow,
+    let proof = match proof.try_into() {
+        Ok(proof) => proof,
+        Err(err) => {
+            log::error!("Invalid proof: {err}");
+            return VerifyResult::InvalidArgument;
         }
     };
 
@@ -191,7 +252,11 @@ pub unsafe extern "C" fn verify_proof(
 
 #[cfg(test)]
 mod tests {
-    use post::pow::randomx::RandomXFlag;
+    use std::ptr::null_mut;
+
+    use post::{
+        initialize::Initialize, metadata::ProofMetadata, pow::randomx::RandomXFlag, prove::Proof,
+    };
 
     #[test]
     fn datadir_must_be_utf8() {
@@ -210,6 +275,7 @@ mod tests {
             1,
             0,
             Default::default(),
+            null_mut(),
         );
         assert!(result.unwrap_err().to_string().contains("Utf8Error"));
     }
@@ -230,12 +296,9 @@ mod tests {
                 std::ptr::null(),
                 super::Proof {
                     nonce: 0,
-                    indices: crate::ArrayU8 {
-                        ptr: std::ptr::null_mut(),
-                        len: 0,
-                        cap: 0,
-                    },
+                    indices: crate::ArrayU8::default(),
                     pow: 0,
+                    pow_creator: crate::ArrayU8::default(),
                 },
                 std::ptr::null(),
                 super::Config {
@@ -248,5 +311,89 @@ mod tests {
             )
         };
         assert_eq!(result, super::VerifyResult::InvalidArgument);
+    }
+
+    #[test]
+    fn test_end_to_end() {
+        // Initialize some data first
+        let labels_per_unit = 200;
+        let datadir = tempfile::tempdir().unwrap();
+
+        let cfg = post::config::Config {
+            k1: 10,
+            k2: 10,
+            k3: 10,
+            pow_difficulty: [
+                0x0f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                0xff, 0xff, 0xff, 0xff,
+            ],
+            scrypt: post::ScryptParams::new(0, 0, 0),
+        };
+
+        post::initialize::CpuInitializer::new(cfg.scrypt)
+            .initialize(
+                datadir.path(),
+                &[0u8; 32],
+                &[0u8; 32],
+                labels_per_unit,
+                2,
+                labels_per_unit,
+                None,
+            )
+            .unwrap();
+
+        let pow_flags = RandomXFlag::get_recommended_flags();
+
+        // Create verifier
+        let mut verifier = std::ptr::null_mut();
+        let result: crate::post_impl::VerifyResult = super::new_verifier(pow_flags, &mut verifier);
+        assert_eq!(result, super::VerifyResult::Ok);
+        assert!(!verifier.is_null());
+
+        let challenge = b"hello world, challenge me!!!!!!!";
+        let miner_id = &[77u8; 32];
+
+        // Create proof without miner ID
+        let data_dir_cstr = std::ffi::CString::new(datadir.path().to_str().unwrap()).unwrap();
+        let cproof = crate::post_impl::generate_proof(
+            data_dir_cstr.as_ptr(),
+            challenge.as_ptr(),
+            cfg,
+            16,
+            1,
+            pow_flags,
+            miner_id.as_ptr(),
+        );
+
+        let proof: Proof = unsafe { *cproof }.try_into().unwrap();
+        assert_eq!(proof.pow_creator, Some(miner_id));
+
+        let proof_metadata = ProofMetadata {
+            node_id: [0u8; 32],
+            commitment_atx_id: [0u8; 32],
+            challenge: *challenge,
+            num_units: 2,
+            labels_per_unit,
+        };
+
+        let result =
+            unsafe { crate::post_impl::verify_proof(verifier, *cproof, &proof_metadata as _, cfg) };
+
+        assert_eq!(result, super::VerifyResult::Ok);
+
+        // Modify the proof to not include pow_creator ID and verify again
+        let invalid_proof = crate::post_impl::Proof {
+            pow_creator: crate::ArrayU8::default(),
+            ..unsafe { *cproof }
+        };
+
+        let result = unsafe {
+            crate::post_impl::verify_proof(verifier, invalid_proof, &proof_metadata as _, cfg)
+        };
+        assert_eq!(result, super::VerifyResult::Invalid);
+
+        unsafe { super::free_proof(cproof) };
+        super::free_verifier(verifier);
     }
 }

--- a/ffi/src/post_impl.rs
+++ b/ffi/src/post_impl.rs
@@ -27,8 +27,8 @@ pub struct Proof {
     pow_creator: ArrayU8,
 }
 
-impl From<prove::Proof<'_, '_>> for Proof {
-    fn from(proof: prove::Proof<'_, '_>) -> Self {
+impl From<prove::Proof<'_>> for Proof {
+    fn from(proof: prove::Proof) -> Self {
         let mut indices = ManuallyDrop::new(proof.indices.into_owned());
         let (ptr, len, cap) = (indices.as_mut_ptr(), indices.len(), indices.capacity());
 
@@ -51,10 +51,10 @@ impl From<prove::Proof<'_, '_>> for Proof {
     }
 }
 
-impl TryInto<prove::Proof<'_, '_>> for Proof {
+impl TryInto<prove::Proof<'_>> for Proof {
     type Error = Box<dyn Error>;
 
-    fn try_into(self) -> Result<prove::Proof<'static, 'static>, Self::Error> {
+    fn try_into(self) -> Result<prove::Proof<'static>, Self::Error> {
         let indices = unsafe { slice::from_raw_parts(self.indices.ptr, self.indices.len) };
         let pow_creator = if self.pow_creator.ptr.is_null() {
             None
@@ -352,7 +352,7 @@ mod tests {
         assert!(!verifier.is_null());
 
         let challenge = b"hello world, challenge me!!!!!!!";
-        let miner_id = &[77u8; 32];
+        let miner_id = [77u8; 32];
 
         // Create proof without miner ID
         let data_dir_cstr = std::ffi::CString::new(datadir.path().to_str().unwrap()).unwrap();

--- a/profiler/src/main.rs
+++ b/profiler/src/main.rs
@@ -80,8 +80,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         .build()
         .unwrap();
     let mut pow_prover = pow::MockProver::new();
-    pow_prover.expect_prove().returning(|_, _, _| Ok(0));
-    let prover = Prover8_56::new(challenge, 0..args.nonces, params, &pow_prover)?;
+    pow_prover.expect_prove().returning(|_, _, _, _| Ok(0));
+    let prover = Prover8_56::new(challenge, 0..args.nonces, params, &pow_prover, None)?;
 
     let consume = |_, _| None;
 

--- a/src/pow/mod.rs
+++ b/src/pow/mod.rs
@@ -22,21 +22,23 @@ pub enum Error {
 
 #[automock]
 pub trait Prover {
-    fn prove(
+    fn prove<'a>(
         &self,
         nonce_group: u8,
         challenge: &[u8; 8],
         difficulty: &[u8; 32],
+        miner_id: Option<&'a [u8; 32]>,
     ) -> Result<u64, Error>;
 }
 
 #[automock]
 pub trait PowVerifier {
-    fn verify(
+    fn verify<'a>(
         &self,
         pow: u64,
         nonce_group: u8,
         challenge: &[u8; 8],
         difficulty: &[u8; 32],
+        miner_id: Option<&'a [u8; 32]>,
     ) -> Result<(), Error>;
 }

--- a/src/pow/mod.rs
+++ b/src/pow/mod.rs
@@ -20,6 +20,7 @@ pub enum Error {
     Internal(Box<dyn std::error::Error + Send + Sync>),
 }
 
+#[allow(clippy::needless_lifetimes)] // lifetime is needed for automock
 #[automock]
 pub trait Prover {
     fn prove<'a>(
@@ -31,6 +32,7 @@ pub trait Prover {
     ) -> Result<u64, Error>;
 }
 
+#[allow(clippy::needless_lifetimes)] // lifetime is needed for automock
 #[automock]
 pub trait PowVerifier {
     fn verify<'a>(

--- a/src/pow/randomx.rs
+++ b/src/pow/randomx.rs
@@ -44,12 +44,12 @@ impl PoW {
 }
 
 impl Prover for PoW {
-    fn prove<'a>(
+    fn prove(
         &self,
         nonce_group: u8,
         challenge: &[u8; 8],
         difficulty: &[u8; 32],
-        miner_id: Option<&'a [u8; 32]>,
+        miner_id: Option<&[u8; 32]>,
     ) -> Result<u64, Error> {
         let mut pow_input = [[0u8; 7].as_slice(), [nonce_group].as_slice(), challenge].concat();
         if let Some(miner_id) = miner_id {
@@ -79,13 +79,13 @@ impl Prover for PoW {
 }
 
 impl PowVerifier for PoW {
-    fn verify<'a>(
+    fn verify(
         &self,
         pow: u64,
         nonce_group: u8,
         challenge: &[u8; 8],
         difficulty: &[u8; 32],
-        miner_id: Option<&'a [u8; 32]>,
+        miner_id: Option<&[u8; 32]>,
     ) -> Result<(), Error> {
         let mut pow_input = [
             &pow.to_le_bytes()[0..7],

--- a/src/pow/randomx.rs
+++ b/src/pow/randomx.rs
@@ -44,13 +44,17 @@ impl PoW {
 }
 
 impl Prover for PoW {
-    fn prove(
+    fn prove<'a>(
         &self,
         nonce_group: u8,
         challenge: &[u8; 8],
         difficulty: &[u8; 32],
+        miner_id: Option<&'a [u8; 32]>,
     ) -> Result<u64, Error> {
-        let pow_input = [[0u8; 7].as_slice(), [nonce_group].as_slice(), challenge].concat();
+        let mut pow_input = [[0u8; 7].as_slice(), [nonce_group].as_slice(), challenge].concat();
+        if let Some(miner_id) = miner_id {
+            pow_input.extend_from_slice(miner_id.as_ref());
+        }
 
         let (pow_nonce, _) = (0..2u64.pow(56))
             .into_par_iter()
@@ -75,19 +79,25 @@ impl Prover for PoW {
 }
 
 impl PowVerifier for PoW {
-    fn verify(
+    fn verify<'a>(
         &self,
         pow: u64,
         nonce_group: u8,
         challenge: &[u8; 8],
         difficulty: &[u8; 32],
+        miner_id: Option<&'a [u8; 32]>,
     ) -> Result<(), Error> {
-        let pow_input = [
+        let mut pow_input = [
             &pow.to_le_bytes()[0..7],
             [nonce_group].as_slice(),
             challenge,
         ]
         .concat();
+
+        if let Some(miner_id) = miner_id {
+            pow_input.extend_from_slice(miner_id.as_ref());
+        }
+
         let vm = self.get_vm()?;
         let hash = vm.calculate_hash(pow_input.as_slice())?;
 
@@ -114,15 +124,41 @@ mod tests {
             0xff, 0xff, 0xff, 0xff,
         ];
         let prover = PoW::new(RandomXFlag::get_recommended_flags()).unwrap();
-        let pow = prover.prove(nonce, challenge, difficulty).unwrap();
-        prover.verify(pow, nonce, challenge, difficulty).unwrap();
+        let pow = prover.prove(nonce, challenge, difficulty, None).unwrap();
+        prover
+            .verify(pow, nonce, challenge, difficulty, None)
+            .unwrap();
+    }
+
+    #[test]
+    fn test_pow_miner_id_matters() {
+        let nonce = 7;
+        let challenge = b"hello!!!";
+        let difficulty = &[
+            0x0f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff,
+        ];
+        let prover = PoW::new(RandomXFlag::get_recommended_flags()).unwrap();
+
+        let pow = prover
+            .prove(nonce, challenge, difficulty, Some(&[1; 32]))
+            .unwrap();
+        prover
+            .verify(pow, nonce, challenge, difficulty, None)
+            .unwrap_err();
+
+        let pow = prover.prove(nonce, challenge, difficulty, None).unwrap();
+        prover
+            .verify(pow, nonce, challenge, difficulty, Some(&[1; 32]))
+            .unwrap_err();
     }
 
     #[test]
     fn reject_invalid_pow() {
         let prover = PoW::new(RandomXFlag::get_recommended_flags()).unwrap();
         // difficulty 0 is impossible to be met
-        assert!(prover.verify(0, 0, b"challeng", &[0; 32]).is_err());
+        assert!(prover.verify(0, 0, b"challeng", &[0; 32], None).is_err());
     }
 
     #[test]

--- a/src/prove.rs
+++ b/src/prove.rs
@@ -32,18 +32,26 @@ const AES_BATCH: usize = 8; // will use encrypt8 asm method
 const CHUNK_SIZE: usize = BLOCK_SIZE * AES_BATCH;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Proof<'a> {
+pub struct Proof<'a, 'b> {
     pub nonce: u32,
     pub indices: Cow<'a, [u8]>,
     pub pow: u64,
+    pub pow_creator: Option<&'b [u8; 32]>,
 }
 
-impl Proof<'_> {
-    pub fn new(nonce: u32, indices: &[u64], num_labels: u64, pow: u64) -> Self {
+impl<'a> Proof<'static, 'a> {
+    pub fn new(
+        nonce: u32,
+        indices: &[u64],
+        num_labels: u64,
+        pow: u64,
+        pow_creator: Option<&'a [u8; 32]>,
+    ) -> Self {
         Self {
             nonce,
             indices: Cow::Owned(compress_indices(indices, required_bits(num_labels))),
             pow,
+            pow_creator,
         }
     }
 }
@@ -109,6 +117,7 @@ impl Prover8_56 {
         nonces: Range<u32>,
         params: ProvingParams,
         pow_prover: &P,
+        miner_id: Option<&[u8; 32]>,
     ) -> eyre::Result<Self> {
         // TODO consider to relax it to allow any range of nonces
         eyre::ensure!(
@@ -127,6 +136,7 @@ impl Prover8_56 {
                     nonce_group.try_into()?,
                     challenge[..8].try_into().unwrap(),
                     &params.pow_difficulty,
+                    miner_id,
                 )?;
                 log::debug!("proof of work: {pow}");
 
@@ -252,14 +262,15 @@ impl Prover for Prover8_56 {
 }
 
 /// Generate a proof that data is still held, given the challenge.
-pub fn generate_proof(
+pub fn generate_proof<'a>(
     datadir: &Path,
     challenge: &[u8; 32],
     cfg: Config,
     nonces: usize,
     threads: usize,
     pow_flags: RandomXFlag,
-) -> eyre::Result<Proof<'static>> {
+    miner_id: Option<&'a [u8; 32]>,
+) -> eyre::Result<Proof<'static, 'a>> {
     let metadata = metadata::load(datadir).wrap_err("loading metadata")?;
     let params = ProvingParams::new(&metadata, &cfg)?;
     log::info!("generating proof with PoW flags: {pow_flags:?} and params: {params:?}");
@@ -282,6 +293,7 @@ pub fn generate_proof(
                 start_nonce..end_nonce,
                 params.clone(),
                 &pow_prover,
+                miner_id,
             )
             .wrap_err("creating prover")
         })?;
@@ -310,7 +322,7 @@ pub fn generate_proof(
             let num_labels = metadata.num_units as u64 * metadata.labels_per_unit;
             let pow = prover.get_pow(nonce).unwrap();
             log::info!("Found proof for nonce: {nonce}, pow: {pow} with {indices:?} indices");
-            return Ok(Proof::new(nonce, &indices, num_labels, pow));
+            return Ok(Proof::new(nonce, &indices, num_labels, pow, miner_id));
         }
 
         (start_nonce, end_nonce) = (end_nonce, end_nonce + nonces as u32);
@@ -321,7 +333,7 @@ pub fn generate_proof(
 mod tests {
     use super::*;
     use crate::{compression::decompress_indexes, difficulty::proving_difficulty};
-    use mockall::predicate::eq;
+    use mockall::predicate::{always, eq};
     use rand::{thread_rng, RngCore};
     use scrypt_jane::scrypt::ScryptParams;
     use std::{collections::HashMap, iter::repeat};
@@ -330,7 +342,7 @@ mod tests {
     fn creating_proof() {
         let indices = vec![0, 1, 2, 3, 4, 5, 6, 7, 8];
         let keep_bits = 4;
-        let proof = Proof::new(7, &indices, 9, 77);
+        let proof = Proof::new(7, &indices, 9, 77, None);
         assert_eq!(7, proof.nonce);
         assert_eq!(77, proof.pow);
         assert_eq!(
@@ -361,20 +373,20 @@ mod tests {
 
         pow_prover
             .expect_prove()
-            .with(eq(0), eq([0; 8]), eq(cfg.pow_difficulty))
+            .with(eq(0), eq([0; 8]), eq(cfg.pow_difficulty), always())
             .once()
-            .returning(|_, _, _| Ok(0));
-        assert!(Prover8_56::new(&[0; 32], 0..16, params.clone(), &pow_prover).is_ok());
+            .returning(|_, _, _, _| Ok(0));
+        assert!(Prover8_56::new(&[0; 32], 0..16, params.clone(), &pow_prover, None).is_ok());
 
         pow_prover
             .expect_prove()
-            .with(eq(1), eq([0; 8]), eq(cfg.pow_difficulty))
+            .with(eq(1), eq([0; 8]), eq(cfg.pow_difficulty), always())
             .once()
-            .returning(|_, _, _| Ok(0));
-        assert!(Prover8_56::new(&[0; 32], 16..32, params.clone(), &pow_prover).is_ok());
+            .returning(|_, _, _, _| Ok(0));
+        assert!(Prover8_56::new(&[0; 32], 16..32, params.clone(), &pow_prover, None).is_ok());
 
-        assert!(Prover8_56::new(&[0; 32], 0..0, params.clone(), &pow_prover).is_err());
-        assert!(Prover8_56::new(&[0; 32], 1..16, params.clone(), &pow_prover).is_err());
+        assert!(Prover8_56::new(&[0; 32], 0..0, params.clone(), &pow_prover, None).is_err());
+        assert!(Prover8_56::new(&[0; 32], 1..16, params.clone(), &pow_prover, None).is_err());
     }
 
     #[test]
@@ -396,9 +408,9 @@ mod tests {
         pow_prover
             .expect_prove()
             .once()
-            .returning(|_, _, _| Err(pow::Error::PoWNotFound));
+            .returning(|_, _, _, _| Err(pow::Error::PoWNotFound));
         let params = ProvingParams::new(&meta, &cfg).unwrap();
-        assert!(Prover8_56::new(&[0; 32], 0..16, params, &pow_prover).is_err());
+        assert!(Prover8_56::new(&[0; 32], 0..16, params, &pow_prover, None).is_err());
     }
 
     /// Test that PoW threshold is scaled with num_units.
@@ -446,13 +458,14 @@ mod tests {
             pow_difficulty: [0xFF; 32],
         };
         let mut pow_prover = pow::MockProver::new();
-        pow_prover.expect_prove().returning(|_, _, _| Ok(0));
+        pow_prover.expect_prove().returning(|_, _, _, _| Ok(0));
 
         let prover = Prover8_56::new(
             challenge,
             0..Prover8_56::NONCES_PER_AES,
             params,
             &pow_prover,
+            None,
         )
         .unwrap();
         let res = prover.prove(&[0u8; 8 * LABEL_SIZE], 0, |nonce, index| {
@@ -489,7 +502,7 @@ mod tests {
             pow_difficulty: [0xFF; 32],
         };
         let mut pow_prover = pow::MockProver::new();
-        pow_prover.expect_prove().returning(|_, _, _| Ok(0));
+        pow_prover.expect_prove().returning(|_, _, _, _| Ok(0));
 
         let indexes = loop {
             let mut indicies = HashMap::<u32, Vec<u64>>::new();
@@ -499,6 +512,7 @@ mod tests {
                 start_nonce..end_nonce,
                 params.clone(),
                 &pow_prover,
+                None,
             )
             .unwrap();
 
@@ -552,7 +566,10 @@ mod tests {
             pow_difficulty: [0xFF; 32],
         };
         let mut pow_prover = pow::MockProver::new();
-        pow_prover.expect_prove().once().returning(|_, _, _| Ok(0));
+        pow_prover
+            .expect_prove()
+            .once()
+            .returning(|_, _, _, _| Ok(0));
         let data = repeat(0..=11) // it's important for range len to not be a multiple of AES block
             .flatten()
             .take(num_labels * LABEL_SIZE)
@@ -563,6 +580,7 @@ mod tests {
             0..Prover8_56::NONCES_PER_AES,
             params,
             &pow_prover,
+            None,
         )
         .unwrap();
 

--- a/src/prove.rs
+++ b/src/prove.rs
@@ -32,20 +32,20 @@ const AES_BATCH: usize = 8; // will use encrypt8 asm method
 const CHUNK_SIZE: usize = BLOCK_SIZE * AES_BATCH;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Proof<'a, 'b> {
+pub struct Proof<'a> {
     pub nonce: u32,
     pub indices: Cow<'a, [u8]>,
     pub pow: u64,
-    pub pow_creator: Option<&'b [u8; 32]>,
+    pub pow_creator: Option<[u8; 32]>,
 }
 
-impl<'a> Proof<'static, 'a> {
+impl Proof<'static> {
     pub fn new(
         nonce: u32,
         indices: &[u64],
         num_labels: u64,
         pow: u64,
-        pow_creator: Option<&'a [u8; 32]>,
+        pow_creator: Option<[u8; 32]>,
     ) -> Self {
         Self {
             nonce,
@@ -262,15 +262,15 @@ impl Prover for Prover8_56 {
 }
 
 /// Generate a proof that data is still held, given the challenge.
-pub fn generate_proof<'a>(
+pub fn generate_proof(
     datadir: &Path,
     challenge: &[u8; 32],
     cfg: Config,
     nonces: usize,
     threads: usize,
     pow_flags: RandomXFlag,
-    miner_id: Option<&'a [u8; 32]>,
-) -> eyre::Result<Proof<'static, 'a>> {
+    miner_id: Option<[u8; 32]>,
+) -> eyre::Result<Proof<'static>> {
     let metadata = metadata::load(datadir).wrap_err("loading metadata")?;
     let params = ProvingParams::new(&metadata, &cfg)?;
     log::info!("generating proof with PoW flags: {pow_flags:?} and params: {params:?}");
@@ -293,7 +293,7 @@ pub fn generate_proof<'a>(
                 start_nonce..end_nonce,
                 params.clone(),
                 &pow_prover,
-                miner_id,
+                miner_id.as_ref(),
             )
             .wrap_err("creating prover")
         })?;

--- a/src/verification.rs
+++ b/src/verification.rs
@@ -143,6 +143,7 @@ impl Verifier {
                 .map_err(|_| Error::NonceGroupOutOfBounds(nonce_group))?,
             &challenge[..8].try_into().unwrap(),
             &params.pow_difficulty,
+            proof.pow_creator,
         )?;
 
         // Verify the number of indices against K2
@@ -281,13 +282,14 @@ mod tests {
         let mut pow_verifier = Box::new(MockPowVerifier::new());
         pow_verifier
             .expect_verify()
-            .returning(|_, _, _, _| Err(crate::pow::Error::InvalidPoW));
+            .returning(|_, _, _, _, _| Err(crate::pow::Error::InvalidPoW));
         let verifier = Verifier::new(pow_verifier);
         let result = verifier.verify(
             &Proof {
                 nonce: 0,
                 indices: Cow::from(vec![1, 2, 3]),
                 pow: 0,
+                pow_creator: None,
             },
             &fake_metadata,
             params,
@@ -313,13 +315,16 @@ mod tests {
             labels_per_unit: 2048,
         };
         let mut pow_verifier = Box::new(MockPowVerifier::new());
-        pow_verifier.expect_verify().returning(|_, _, _, _| Ok(()));
+        pow_verifier
+            .expect_verify()
+            .returning(|_, _, _, _, _| Ok(()));
         let verifier = Verifier::new(pow_verifier);
         {
             let empty_proof = Proof {
                 nonce: 0,
                 indices: Cow::from(vec![]),
                 pow: 0,
+                pow_creator: None,
             };
             let result = verifier.verify(&empty_proof, &fake_metadata, params);
             assert!(matches!(
@@ -335,6 +340,7 @@ mod tests {
                 nonce: 256 * 16,
                 indices: Cow::from(vec![]),
                 pow: 0,
+                pow_creator: None,
             };
             let res = verifier.verify(&nonce_out_of_bounds_proof, &fake_metadata, params);
             assert!(matches!(res, Err(Error::NonceGroupOutOfBounds(256))));
@@ -344,6 +350,7 @@ mod tests {
                 nonce: 0,
                 indices: Cow::from(vec![1, 2, 3]),
                 pow: 0,
+                pow_creator: None,
             };
             let result = verifier.verify(&proof_with_not_enough_indices, &fake_metadata, params);
             assert!(matches!(

--- a/src/verification.rs
+++ b/src/verification.rs
@@ -143,7 +143,7 @@ impl Verifier {
                 .map_err(|_| Error::NonceGroupOutOfBounds(nonce_group))?,
             &challenge[..8].try_into().unwrap(),
             &params.pow_difficulty,
-            proof.pow_creator,
+            proof.pow_creator.as_ref(),
         )?;
 
         // Verify the number of indices against K2

--- a/tests/generate_and_verify.rs
+++ b/tests/generate_and_verify.rs
@@ -15,7 +15,7 @@ fn test_generate_and_verify() {
     let labels_per_unit = 256 * 16;
     let datadir = tempdir().unwrap();
 
-    let miner_id = Some(&[7u8; 32]);
+    let miner_id = Some([7u8; 32]);
 
     let cfg = post::config::Config {
         k1: 23,

--- a/tests/generate_and_verify.rs
+++ b/tests/generate_and_verify.rs
@@ -15,6 +15,8 @@ fn test_generate_and_verify() {
     let labels_per_unit = 256 * 16;
     let datadir = tempdir().unwrap();
 
+    let miner_id = Some(&[7u8; 32]);
+
     let cfg = post::config::Config {
         k1: 23,
         k2: 32,
@@ -37,7 +39,7 @@ fn test_generate_and_verify() {
 
     let pow_flags = RandomXFlag::get_recommended_flags();
     // Generate a proof
-    let proof = generate_proof(datadir.path(), challenge, cfg, 32, 1, pow_flags).unwrap();
+    let proof = generate_proof(datadir.path(), challenge, cfg, 32, 1, pow_flags, miner_id).unwrap();
 
     // Verify the proof
     let metadata = ProofMetadata {
@@ -99,7 +101,7 @@ fn test_generate_and_verify_difficulty_msb_not_zero() {
 
     let pow_flags = RandomXFlag::get_recommended_flags();
     // Generate a proof
-    let proof = generate_proof(datadir.path(), challenge, cfg, 32, 1, pow_flags).unwrap();
+    let proof = generate_proof(datadir.path(), challenge, cfg, 32, 1, pow_flags, None).unwrap();
 
     // Verify the proof
     let metadata = ProofMetadata {


### PR DESCRIPTION
Part of https://github.com/spacemeshos/go-spacemesh/issues/4656

Add an optional miner ID as input to the K2 PoW. The ID is appended to the end of k2 pow input. It is now:
```
pow_input = [
            pow_nonce (7B),
            nonce_group (1B)
            challenge (the first 8B of the 32B post challenge),
            miner_id (optional 32B)
        ]
```