### PR TITLE
Add benching K2 PoW to profiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,9 @@ jobs:
         run: cargo build -p profiler --release
         env:
           RUSTFLAGS: ${{ matrix.rustflags }}
+          # https://github.com/tevador/RandomX/issues/262
+          # https://github.com/tari-project/randomx-rs/issues/48
+          SDKROOT: "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk"
       - name: Archive profiler artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,7 @@ version = "0.65.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -212,6 +212,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
 name = "bitvec"
@@ -404,7 +410,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex 0.2.4",
  "indexmap",
  "strsim",
@@ -431,7 +437,7 @@ checksum = "84080e799e54cff944f4b4a4b0e71630b0e0443b25b985175c7dddc1a859b749"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex 0.4.1",
  "strsim",
 ]
@@ -1348,7 +1354,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "libc",
  "static_assertions",
@@ -1463,7 +1469,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66d46a57dfd1bb6fbee28986e92d39db9b941719dcf6b539c64242006d3c030d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cl-sys",
  "enum_primitive",
  "num-complex",
@@ -1741,6 +1747,7 @@ dependencies = [
  "clap 4.2.4",
  "env_logger",
  "eyre",
+ "hex",
  "libc",
  "post-rs",
  "rand",
@@ -1757,7 +1764,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f1b898011ce9595050a68e60f90bad083ff2987a695a42357134c8381fba70"
 dependencies = [
  "bit-set",
- "bitflags",
+ "bitflags 1.3.2",
  "byteorder",
  "lazy_static",
  "num-traits 0.2.15",
@@ -1859,9 +1866,9 @@ dependencies = [
 [[package]]
 name = "randomx-rs"
 version = "1.1.15"
-source = "git+https://github.com/spacemeshos/randomx-rs?rev=18080c74da8b179a2e99d2eef4e0c0279fd6f75a#18080c74da8b179a2e99d2eef4e0c0279fd6f75a"
+source = "git+https://github.com/spacemeshos/randomx-rs?rev=6f2bf32af7219a5f9ae929c3020242ecc7c6dd6a#6f2bf32af7219a5f9ae929c3020242ecc7c6dd6a"
 dependencies = [
- "bitflags",
+ "bitflags 2.3.3",
  "libc",
  "thiserror",
 ]
@@ -1894,7 +1901,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1903,7 +1910,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1997,7 +2004,7 @@ version = "0.37.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b864d3c18a5785a05953adeed93e2dca37ed30f18e69bba9f30079d51f363f"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ bitvec = "1.0.1"
 rayon = "1.6.1"
 rand = "0.8.5"
 log = "0.4.17"
-randomx-rs = { git = "https://github.com/spacemeshos/randomx-rs", rev = "18080c74da8b179a2e99d2eef4e0c0279fd6f75a" }
+randomx-rs = { git = "https://github.com/spacemeshos/randomx-rs", rev = "6f2bf32af7219a5f9ae929c3020242ecc7c6dd6a" }
 
 
 primitive-types = "0.12.1"

--- a/docs/profiler.md
+++ b/docs/profiler.md
@@ -84,9 +84,23 @@ Based on these outputs you need to decide what is the best configuration for you
 ## Is that all that is happening during the proof generation?
 Additionally for every group of 16 nonces there is an additional computation - often referred to as `k2pow` - required. It serves as mitigation against some possible attacks by dishonest smeshers.
 
-On the mainnet, each set of 64 nonces requires one `k2pow` computation. In the case of a low-end CPU with a hash rate of 500 in the [RandomX benchmark](https://xmrig.com/benchmark), approximately 2 minutes and 30 seconds are needed to process 1 SU (a Space Unit on the mainnet equates to 64GiB). This processing time scales up linearly with the hash rate. You may want to check out the single and multicore results from the benchmark for more details.
+On the mainnet, each set of 16 nonces requires one `k2pow` computation. In the case of a low-end CPU with a hash rate of 500 h/s in the [RandomX benchmark](https://xmrig.com/benchmark), approximately 2 minutes and 30 seconds are needed to create a PoWs for 4 SUs (a Space Unit on the mainnet equates to 64GiB) and 64 nonces (4xPoW). This processing time scales down linearly with the hash rate and it scales up linearily with the number of SUs. You may want to check out the single and multicore results from the benchmark for more details.
 
 Please add your estimate (number of SU x the result of the RandomX benchmark) to the total time needed to generate a proof.
+
+## Benchmarking K2 PoW
+The `profiler` allows benchmarking the speed of proof of work. The profiler always executes PoW for 1 SU to speed up measurement and automatically scales up the result by the requested number of units.
+
+To understand the inner mechanics of RandomX proof of work, take a look at its [specification](https://github.com/tevador/RandomX/blob/master/doc/specs.md).
+
+Refer to `profiler pow --help` to understand how to use the profiler to benchmark the K2 PoW. Most users will need to tweak three arguments:
+
+* `--threads`,
+* `--num-units`,
+* `--nonces`
+
+### Example
+`profiler pow --nonces 288 --num-units 16 --iterations 10 --threads 2 --randomx-mode fast`
 
 # Tips & Hints
 

--- a/profiler/Cargo.toml
+++ b/profiler/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 clap = { version = "4.1.11", features = ["derive"] }
 env_logger = "0.10.0"
 eyre = "0.6.8"
+hex = "0.4.3"
 libc = "0.2.146"
 post-rs = { path = "../" }
 rand = "0.8.5"


### PR DESCRIPTION
Closes #108 

Added a subcommand to the `profiler` to bench K2 proof of work. The benchmark always runs PoW for 1 unit and it scales the result by the passed number of units and nonce groups (nonces/16). The default difficulty is as on the mainnet.

It logs messages onto stderr and prints the result on stdout for scripts (smapp) to pick up.

## Help:
```sh
❯ profiler pow --help
Bench proof of work

Usage: profiler pow [OPTIONS]

Options:
  -i, --iterations <ITERATIONS>
          Iterations to run the benchmark for. The more, the more accurate the result is

          [default: 5]

  -t, --threads <THREADS>
          Number of threads to use. '0' means use all available threads

          [default: 1]

  -n, --nonces <NONCES>
          Number of nonces to attempt in single pass over POS data.

          Each group of 16 nonces requires a separate PoW. Must be a multiple of 16.

          Higher value gives a better chance to find a proof within less passes over the POS data, but also slows down the process.

          [default: 64]

      --num-units <NUM_UNITS>
          Number of units of initialized POS data

          [default: 4]

  -d, --difficulty <DIFFICULTY>
          PoW difficulty, a network parameter

          It's a base parameter for 1 space unit. The actual difficulty for PoW is scaled by the number of initialized space units (the more the harder).

          [default: 000dfb23b0979b4b000000000000000000000000000000000000000000000000]

      --randomx-mode <RANDOMX_MODE>
          Modes of operation for RandomX.

          They are interchangeable as they give the same results but have different purpose and memory requirements.

          [default: fast]

          Possible values:
          - fast:
            Fast mode for proving. Requires 2080 MiB of memory
          - light:
            Light mode for verification. Requires only 256 MiB of memory, but runs significantly slower

  -h, --help
          Print help (see a summary with '-h')
```

## Example output
```sh
Benchmarking PoW for 1 space unit and 16 nonces (the result will be scaled automatically to 4 units and 64 nonces).
RandomX flags: FLAG_HARD_AES | FLAG_FULL_MEM | FLAG_JIT | FLAG_ARGON2_SSSE3 | FLAG_ARGON2_AVX2
Initializing RandomX VMs...
Done initializing RandomX VMs in 29.21s
[0]: 13.30s (scaled: 212.77s)
[1]: 37.95s (scaled: 607.25s)
[2]: 6.84s (scaled: 109.51s)
[3]: 33.03s (scaled: 528.46s)
[4]: 11.45s (scaled: 183.17s)
{
  "randomx_vm_init_time": {
    "secs": 29,
    "nanos": 209630073
  },
  "average_time": {
    "secs": 328,
    "nanos": 230021763
  },
  "iterations": 5
}
```

## Running in light mode:
```sh
❯ profiler pow --randomx-mode=light
```