### PR TITLE
Increase verbosity of proof generation

### DIFF
--- a/profiler/src/main.rs
+++ b/profiler/src/main.rs
@@ -227,7 +227,7 @@ fn proving(args: ProvingArgs) -> eyre::Result<()> {
 
     while total_time < Duration::from_secs(args.duration) {
         let file = util::open_without_cache(&file_path)?;
-        let reader = post::reader::read_from(BufReader::new(file), batch_size, total_size);
+        let reader = post::reader::read_from(BufReader::new(file), batch_size, total_size, None);
         let start = time::Instant::now();
         pool.install(|| {
             reader.par_bridge().for_each(|batch| {


### PR DESCRIPTION
Users currently get very little feedback during proof generation. This leads to concern about whether systems are working properly during the poet window and makes it difficult to understand system performance.

PR contains logging I've personally found useful. 

- (INFO) Inform users when the PoW phase starts and when the Read phase starts.
- (DEBUG) Track number of hashes tried for each nonce group
- (DEBUG) Show when reader starts next postbin file to give some indication of progress - could be expanded to an ETA for time remaining