### PR TITLE
Pick node ID for K2pow from POST/Proof metadata

### DIFF
--- a/benches/pow.rs
+++ b/benches/pow.rs
@@ -31,7 +31,11 @@ fn bench_pow(c: &mut Criterion) {
                 b.iter_batched(
                     rand::random,
                     |nonce| {
-                        pool.install(|| prover.prove(nonce, b"challeng", difficulty, None).unwrap())
+                        pool.install(|| {
+                            prover
+                                .prove(nonce, b"challeng", difficulty, &[7; 32])
+                                .unwrap()
+                        })
                     },
                     BatchSize::SmallInput,
                 )
@@ -48,7 +52,7 @@ fn verify_pow_light_stateless(c: &mut Criterion) {
             |pow| {
                 let prover = PoW::new(flags).unwrap();
                 prover
-                    .verify(pow, 7, b"challeng", &[0xFFu8; 32], None)
+                    .verify(pow, 7, b"challeng", &[0xFF; 32], &[7; 32])
                     .unwrap();
             },
             BatchSize::SmallInput,
@@ -65,7 +69,7 @@ fn verify_pow_light(c: &mut Criterion) {
             rand::random,
             |pow| {
                 prover
-                    .verify(pow, 7, b"challeng", &[0xFFu8; 32], None)
+                    .verify(pow, 7, b"challeng", &[0xFF; 32], &[7; 32])
                     .unwrap();
             },
             BatchSize::SmallInput,
@@ -82,7 +86,7 @@ fn verify_pow_fast(c: &mut Criterion) {
             rand::random,
             |pow| {
                 prover
-                    .verify(pow, 7, b"challeng", &[0xFFu8; 32], None)
+                    .verify(pow, 7, b"challeng", &[0xFF; 32], &[7; 32])
                     .unwrap();
             },
             BatchSize::SmallInput,

--- a/benches/proving.rs
+++ b/benches/proving.rs
@@ -50,8 +50,7 @@ fn prover_bench(c: &mut Criterion) {
                     .times(nonces as usize / 16)
                     .returning(|_, _, _, _| Ok(0));
                 let prover =
-                    Prover8_56::new(CHALLENGE, 0..nonces, params.clone(), &pow_prover, None)
-                        .unwrap();
+                    Prover8_56::new(CHALLENGE, 0..nonces, params, &pow_prover, &[7; 32]).unwrap();
                 b.iter(|| {
                     let f = black_box(|_, _| None);
                     match threads {

--- a/benches/verifying.rs
+++ b/benches/verifying.rs
@@ -31,7 +31,6 @@ fn verifying(c: &mut Criterion) {
         (0..k2 as u64).collect::<Vec<u64>>().as_slice(),
         num_labels,
         0,
-        None,
     );
     let params = VerifyingParams {
         difficulty: u64::MAX,

--- a/ffi/src/post_impl.rs
+++ b/ffi/src/post_impl.rs
@@ -24,7 +24,6 @@ pub struct Proof {
     nonce: u32,
     indices: ArrayU8,
     pow: u64,
-    pow_creator: ArrayU8,
 }
 
 impl From<prove::Proof<'_>> for Proof {
@@ -32,42 +31,23 @@ impl From<prove::Proof<'_>> for Proof {
         let mut indices = ManuallyDrop::new(proof.indices.into_owned());
         let (ptr, len, cap) = (indices.as_mut_ptr(), indices.len(), indices.capacity());
 
-        let pow_creator = proof
-            .pow_creator
-            .map(|creator| {
-                // make a copy of the creator
-                let mut creator = ManuallyDrop::new(creator.to_vec());
-                let (ptr, len, cap) = (creator.as_mut_ptr(), creator.len(), creator.capacity());
-                ArrayU8 { ptr, len, cap }
-            })
-            .unwrap_or_default();
-
         Self {
             nonce: proof.nonce,
             indices: ArrayU8 { ptr, len, cap },
             pow: proof.pow,
-            pow_creator,
         }
     }
 }
 
-impl TryInto<prove::Proof<'_>> for Proof {
-    type Error = Box<dyn Error>;
+impl From<Proof> for prove::Proof<'_> {
+    fn from(val: Proof) -> Self {
+        let indices = unsafe { slice::from_raw_parts(val.indices.ptr, val.indices.len) };
 
-    fn try_into(self) -> Result<prove::Proof<'static>, Self::Error> {
-        let indices = unsafe { slice::from_raw_parts(self.indices.ptr, self.indices.len) };
-        let pow_creator = match (self.pow_creator.ptr, self.pow_creator.len) {
-            (ptr, 32) if !ptr.is_null() => {
-                Some(unsafe { slice::from_raw_parts(ptr, 32) }.try_into()?)
-            }
-            _ => None,
-        };
-        Ok(post::prove::Proof {
-            nonce: self.nonce,
+        post::prove::Proof {
+            nonce: val.nonce,
             indices: Cow::from(indices),
-            pow: self.pow,
-            pow_creator,
-        })
+            pow: val.pow,
+        }
     }
 }
 
@@ -80,13 +60,6 @@ pub unsafe extern "C" fn free_proof(proof: *mut Proof) {
     if !proof.indices.ptr.is_null() {
         Vec::from_raw_parts(proof.indices.ptr, proof.indices.len, proof.indices.cap);
     }
-    if !proof.pow_creator.ptr.is_null() {
-        Vec::from_raw_parts(
-            proof.pow_creator.ptr,
-            proof.pow_creator.len,
-            proof.pow_creator.cap,
-        );
-    }
     // proof and vec will be deallocated on return
 }
 
@@ -95,7 +68,6 @@ pub unsafe extern "C" fn free_proof(proof: *mut Proof) {
 /// If an error occurs, prints it on stderr and returns null.
 /// # Safety
 /// `challenge` must be a 32-byte array.
-/// `miner_id` must be null or point to a 32-byte array.
 #[no_mangle]
 pub extern "C" fn generate_proof(
     datadir: *const c_char,
@@ -104,11 +76,8 @@ pub extern "C" fn generate_proof(
     nonces: usize,
     threads: usize,
     pow_flags: RandomXFlag,
-    miner_id: *const c_uchar,
 ) -> *mut Proof {
-    match _generate_proof(
-        datadir, challenge, cfg, nonces, threads, pow_flags, miner_id,
-    ) {
+    match _generate_proof(datadir, challenge, cfg, nonces, threads, pow_flags) {
         Ok(proof) => Box::into_raw(proof),
         Err(e) => {
             //TODO(poszu) communicate errors better
@@ -125,7 +94,6 @@ fn _generate_proof(
     nonces: usize,
     threads: usize,
     pow_flags: RandomXFlag,
-    miner_id: *const c_uchar,
 ) -> Result<Box<Proof>, Box<dyn Error>> {
     let datadir = unsafe { CStr::from_ptr(datadir) };
     let datadir = Path::new(
@@ -137,16 +105,7 @@ fn _generate_proof(
     let challenge = unsafe { std::slice::from_raw_parts(challenge, 32) };
     let challenge = challenge.try_into()?;
 
-    let miner_id = if miner_id.is_null() {
-        None
-    } else {
-        let miner_id = unsafe { std::slice::from_raw_parts(miner_id, 32) };
-        Some(miner_id.try_into()?)
-    };
-
-    let proof = prove::generate_proof(
-        datadir, challenge, cfg, nonces, threads, pow_flags, miner_id,
-    )?;
+    let proof = prove::generate_proof(datadir, challenge, cfg, nonces, threads, pow_flags)?;
     Ok(Box::new(Proof::from(proof)))
 }
 
@@ -247,11 +206,7 @@ pub unsafe extern "C" fn verify_proof(
 
 #[cfg(test)]
 mod tests {
-    use std::ptr::null_mut;
-
-    use post::{
-        initialize::Initialize, metadata::ProofMetadata, pow::randomx::RandomXFlag, prove::Proof,
-    };
+    use post::{initialize::Initialize, metadata::ProofMetadata, pow::randomx::RandomXFlag};
 
     #[test]
     fn datadir_must_be_utf8() {
@@ -270,7 +225,6 @@ mod tests {
             1,
             0,
             Default::default(),
-            null_mut(),
         );
         assert!(result.unwrap_err().to_string().contains("Utf8Error"));
     }
@@ -293,7 +247,6 @@ mod tests {
                     nonce: 0,
                     indices: crate::ArrayU8::default(),
                     pow: 0,
-                    pow_creator: crate::ArrayU8::default(),
                 },
                 std::ptr::null(),
                 super::Config {
@@ -326,10 +279,10 @@ mod tests {
             scrypt: post::ScryptParams::new(0, 0, 0),
         };
 
-        post::initialize::CpuInitializer::new(cfg.scrypt)
+        let meta = post::initialize::CpuInitializer::new(cfg.scrypt)
             .initialize(
                 datadir.path(),
-                &[0u8; 32],
+                &[77; 32],
                 &[0u8; 32],
                 labels_per_unit,
                 2,
@@ -347,7 +300,6 @@ mod tests {
         assert!(!verifier.is_null());
 
         let challenge = b"hello world, challenge me!!!!!!!";
-        let miner_id = [77u8; 32];
 
         // Create proof without miner ID
         let data_dir_cstr = std::ffi::CString::new(datadir.path().to_str().unwrap()).unwrap();
@@ -358,18 +310,14 @@ mod tests {
             16,
             1,
             pow_flags,
-            miner_id.as_ptr(),
         );
 
-        let proof: Proof = unsafe { *cproof }.try_into().unwrap();
-        assert_eq!(proof.pow_creator, Some(miner_id));
-
         let proof_metadata = ProofMetadata {
-            node_id: [0u8; 32],
-            commitment_atx_id: [0u8; 32],
+            node_id: meta.node_id,
+            commitment_atx_id: meta.commitment_atx_id,
             challenge: *challenge,
-            num_units: 2,
-            labels_per_unit,
+            num_units: meta.num_units,
+            labels_per_unit: meta.labels_per_unit,
         };
 
         let result =
@@ -377,10 +325,12 @@ mod tests {
 
         assert_eq!(result, super::VerifyResult::Ok);
 
-        // Modify the proof to not include pow_creator ID and verify again
-        let invalid_proof = crate::post_impl::Proof {
-            pow_creator: crate::ArrayU8::default(),
-            ..unsafe { *cproof }
+        // Modify the proof to have different k2pow
+        let invalid_proof = unsafe {
+            crate::post_impl::Proof {
+                pow: (*cproof).pow - 1,
+                ..*cproof
+            }
         };
 
         let result = unsafe {

--- a/profiler/src/main.rs
+++ b/profiler/src/main.rs
@@ -220,7 +220,7 @@ fn proving(args: ProvingArgs) -> eyre::Result<()> {
 
     let mut pow_prover = pow::MockProver::new();
     pow_prover.expect_prove().returning(|_, _, _, _| Ok(0));
-    let prover = Prover8_56::new(challenge, 0..args.nonces, params, &pow_prover, None)?;
+    let prover = Prover8_56::new(challenge, 0..args.nonces, params, &pow_prover, &[7; 32])?;
 
     let mut total_time = time::Duration::from_secs(0);
     let mut processed = 0;
@@ -286,7 +286,7 @@ fn pow(args: PowArgs) -> eyre::Result<()> {
     pool.install(|| -> eyre::Result<()> {
         for i in 0..args.iterations {
             let start = time::Instant::now();
-            prover.prove(7, &i.to_le_bytes(), &args.difficulty, None)?;
+            prover.prove(7, &i.to_le_bytes(), &args.difficulty, &[7; 32])?;
             let duration = start.elapsed();
             eprintln!(
                 "[{i}]: {duration:.2?} (scaled: {:.2?})",

--- a/src/pow/mod.rs
+++ b/src/pow/mod.rs
@@ -20,27 +20,25 @@ pub enum Error {
     Internal(Box<dyn std::error::Error + Send + Sync>),
 }
 
-#[allow(clippy::needless_lifetimes)] // lifetime is needed for automock
 #[automock]
 pub trait Prover {
-    fn prove<'a>(
+    fn prove(
         &self,
         nonce_group: u8,
         challenge: &[u8; 8],
         difficulty: &[u8; 32],
-        miner_id: Option<&'a [u8; 32]>,
+        miner_id: &[u8; 32],
     ) -> Result<u64, Error>;
 }
 
-#[allow(clippy::needless_lifetimes)] // lifetime is needed for automock
 #[automock]
 pub trait PowVerifier {
-    fn verify<'a>(
+    fn verify(
         &self,
         pow: u64,
         nonce_group: u8,
         challenge: &[u8; 8],
         difficulty: &[u8; 32],
-        miner_id: Option<&'a [u8; 32]>,
+        miner_id: &[u8; 32],
     ) -> Result<(), Error>;
 }

--- a/src/verification.rs
+++ b/src/verification.rs
@@ -143,7 +143,7 @@ impl Verifier {
                 .map_err(|_| Error::NonceGroupOutOfBounds(nonce_group))?,
             &challenge[..8].try_into().unwrap(),
             &params.pow_difficulty,
-            proof.pow_creator.as_ref(),
+            &metadata.node_id,
         )?;
 
         // Verify the number of indices against K2
@@ -288,7 +288,6 @@ mod tests {
                 nonce: 0,
                 indices: Cow::from(vec![1, 2, 3]),
                 pow: 0,
-                pow_creator: None,
             },
             &fake_metadata,
             params,
@@ -323,7 +322,6 @@ mod tests {
                 nonce: 0,
                 indices: Cow::from(vec![]),
                 pow: 0,
-                pow_creator: None,
             };
             let result = verifier.verify(&empty_proof, &fake_metadata, params);
             assert!(matches!(
@@ -339,7 +337,6 @@ mod tests {
                 nonce: 256 * 16,
                 indices: Cow::from(vec![]),
                 pow: 0,
-                pow_creator: None,
             };
             let res = verifier.verify(&nonce_out_of_bounds_proof, &fake_metadata, params);
             assert!(matches!(res, Err(Error::NonceGroupOutOfBounds(256))));
@@ -349,7 +346,6 @@ mod tests {
                 nonce: 0,
                 indices: Cow::from(vec![1, 2, 3]),
                 pow: 0,
-                pow_creator: None,
             };
             let result = verifier.verify(&proof_with_not_enough_indices, &fake_metadata, params);
             assert!(matches!(

--- a/tests/generate_and_verify.rs
+++ b/tests/generate_and_verify.rs
@@ -15,8 +15,6 @@ fn test_generate_and_verify() {
     let labels_per_unit = 256 * 16;
     let datadir = tempdir().unwrap();
 
-    let miner_id = Some([7u8; 32]);
-
     let cfg = post::config::Config {
         k1: 23,
         k2: 32,
@@ -28,7 +26,7 @@ fn test_generate_and_verify() {
     let metadata = CpuInitializer::new(cfg.scrypt)
         .initialize(
             datadir.path(),
-            &[0u8; 32],
+            &[77; 32],
             &[0u8; 32],
             labels_per_unit,
             31,
@@ -39,7 +37,7 @@ fn test_generate_and_verify() {
 
     let pow_flags = RandomXFlag::get_recommended_flags();
     // Generate a proof
-    let proof = generate_proof(datadir.path(), challenge, cfg, 32, 1, pow_flags, miner_id).unwrap();
+    let proof = generate_proof(datadir.path(), challenge, cfg, 32, 1, pow_flags).unwrap();
 
     // Verify the proof
     let metadata = ProofMetadata {
@@ -101,7 +99,7 @@ fn test_generate_and_verify_difficulty_msb_not_zero() {
 
     let pow_flags = RandomXFlag::get_recommended_flags();
     // Generate a proof
-    let proof = generate_proof(datadir.path(), challenge, cfg, 32, 1, pow_flags, None).unwrap();
+    let proof = generate_proof(datadir.path(), challenge, cfg, 32, 1, pow_flags).unwrap();
 
     // Verify the proof
     let metadata = ProofMetadata {


### PR DESCRIPTION
Removed the optional `miner_id` from C FFI. It was used to pass the ID that is generating the K2 PoW (it used to be optional in the transitional phase before the mainnet). Now it is picked from:
- post metadata for proof generation,
- proof metadata for proof verification.
