### PR TITLE
Add mode for watching PID and exit if it dies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,6 +1536,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2503,6 +2512,7 @@ dependencies = [
  "prost",
  "rcgen",
  "rstest 0.18.2",
+ "sysinfo",
  "tempfile",
  "tokio",
  "tokio-stream",
@@ -2637,6 +2647,21 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sysinfo"
+version = "0.29.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a18d114d420ada3a891e6bc8e96a2023402203296a47cdd65083377dad18ba5"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "winapi",
+]
 
 [[package]]
 name = "tap"

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -25,6 +25,7 @@ env_logger = "0.10.0"
 clap = { version = "4.4.4", features = ["derive"] }
 hex = "0.4.3"
 mockall = "0.11.4"
+sysinfo = "0.29.10"
 
 [build-dependencies]
 tonic-build = "0.10.0"


### PR DESCRIPTION
Added `--watch-pid=<PID>` CLI argument. When passed, the post-service will watch this PID and quit when it's not alive.