### PR TITLE
Use N,R,P scrypt params instead of factors in config

### DIFF
--- a/benches/verifying.rs
+++ b/benches/verifying.rs
@@ -1,5 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use post::{
+    config::ScryptParams,
     metadata::ProofMetadata,
     pow::randomx::{PoW, RandomXFlag},
     prove::Proof,
@@ -7,8 +8,6 @@ use post::{
 };
 #[cfg(not(windows))]
 use pprof::criterion::{Output, PProfProfiler};
-
-use scrypt_jane::scrypt::ScryptParams;
 
 fn verifying(c: &mut Criterion) {
     let challenge = b"hello world, challenge me!!!!!!!";
@@ -37,7 +36,7 @@ fn verifying(c: &mut Criterion) {
         k2,
         k3,
         pow_difficulty: [0xFF; 32],
-        scrypt: ScryptParams::new(12, 0, 0),
+        scrypt: ScryptParams::new(8192, 1, 1),
     };
 
     c.bench_function("verify", |b| {

--- a/ffi/src/initialization.rs
+++ b/ffi/src/initialization.rs
@@ -1,9 +1,9 @@
 use std::{error::Error, ffi::c_char, fmt::Debug};
 
 use post::{
+    config::ScryptParams,
     initialize::{CpuInitializer, Initialize},
     pos_verification::VerificationError,
-    ScryptParams,
 };
 use scrypt_ocl::{ocl::DeviceType, OpenClInitializer, ProviderId};
 
@@ -186,11 +186,7 @@ fn _new_initializer(
     };
 
     let instance: Box<dyn Initialize> = match provider_id {
-        CPU_PROVIDER_ID => Box::new(CpuInitializer::new(ScryptParams::new(
-            n.ilog2() as u8 - 1,
-            0,
-            0,
-        ))),
+        CPU_PROVIDER_ID => Box::new(CpuInitializer::new(ScryptParams::new(n, 1, 1))),
         id => Box::new(OpenClInitializer::new(
             Some(ProviderId(id)),
             n,
@@ -260,8 +256,8 @@ mod tests {
     };
 
     use post::{
+        config::ScryptParams,
         initialize::{CpuInitializer, Initialize, MockInitialize},
-        ScryptParams,
     };
     use tempfile::tempdir;
 
@@ -299,7 +295,7 @@ mod tests {
 
         let mut expected = Vec::<u8>::with_capacity(indices.clone().count());
 
-        CpuInitializer::new(ScryptParams::new(4, 0, 0))
+        CpuInitializer::new(ScryptParams::new(32, 1, 1))
             .initialize_to(
                 &mut expected,
                 &[0u8; 32],
@@ -426,7 +422,7 @@ mod tests {
             k2: 32,
             k3: 10,
             pow_difficulty: [0xFF; 32],
-            scrypt: ScryptParams::new(0, 0, 0),
+            scrypt: ScryptParams::new(2, 1, 1),
         };
 
         CpuInitializer::new(cfg.scrypt)
@@ -439,7 +435,7 @@ mod tests {
         assert_eq!(VerifyResult::Ok, result);
 
         // verify with wrong scrypt params
-        let wrong_scrypt = ScryptParams::new(2, 0, 0);
+        let wrong_scrypt = ScryptParams::new(4, 1, 1);
         let result = verify_pos(datapath.as_ptr(), null(), null(), 100.0, wrong_scrypt);
         assert_eq!(VerifyResult::Invalid, result);
 

--- a/ffi/src/post_impl.rs
+++ b/ffi/src/post_impl.rs
@@ -8,10 +8,9 @@ use std::{
     sync::atomic::AtomicBool,
 };
 
-pub use post::config::Config;
-pub use post::metadata::ProofMetadata;
-pub use post::ScryptParams;
 use post::{
+    config::Config,
+    metadata::ProofMetadata,
     pow::randomx::{PoW, RandomXFlag},
     prove,
     verification::{Verifier, VerifyingParams},
@@ -208,7 +207,10 @@ pub unsafe extern "C" fn verify_proof(
 
 #[cfg(test)]
 mod tests {
-    use post::{initialize::Initialize, metadata::ProofMetadata, pow::randomx::RandomXFlag};
+    use post::{
+        config::ScryptParams, initialize::Initialize, metadata::ProofMetadata,
+        pow::randomx::RandomXFlag,
+    };
 
     #[test]
     fn datadir_must_be_utf8() {
@@ -218,7 +220,7 @@ mod tests {
             k2: 20,
             k3: 20,
             pow_difficulty: [0xFF; 32],
-            scrypt: super::ScryptParams::new(1, 1, 1),
+            scrypt: ScryptParams::new(2, 1, 1),
         };
         let result = super::_generate_proof(
             datadir.as_ptr(),
@@ -256,7 +258,7 @@ mod tests {
                     k2: 2,
                     k3: 2,
                     pow_difficulty: [0xFF; 32],
-                    scrypt: super::ScryptParams::new(1, 0, 0),
+                    scrypt: ScryptParams::new(2, 1, 1),
                 },
             )
         };
@@ -278,7 +280,7 @@ mod tests {
                 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
                 0xff, 0xff, 0xff, 0xff,
             ],
-            scrypt: post::ScryptParams::new(0, 0, 0),
+            scrypt: ScryptParams::new(2, 1, 1),
         };
 
         let meta = post::initialize::CpuInitializer::new(cfg.scrypt)

--- a/scrypt-ocl/src/lib.rs
+++ b/scrypt-ocl/src/lib.rs
@@ -356,8 +356,8 @@ impl Initialize for OpenClInitializer {
 #[cfg(test)]
 mod tests {
     use post::{
+        config::ScryptParams,
         initialize::{CpuInitializer, Initialize},
-        ScryptParams,
     };
     use rstest::rstest;
 
@@ -386,7 +386,7 @@ mod tests {
             .unwrap();
 
         let mut expected = Vec::with_capacity(1);
-        CpuInitializer::new(ScryptParams::new(12, 0, 0))
+        CpuInitializer::new(ScryptParams::new(8192, 1, 1))
             .initialize_to(&mut expected, &[0u8; 32], 0..1, None)
             .unwrap();
 
@@ -411,7 +411,7 @@ mod tests {
         let mut expected =
             Vec::<u8>::with_capacity(usize::try_from(indices.end - indices.start).unwrap());
 
-        CpuInitializer::new(ScryptParams::new(n.ilog2() as u8 - 1, 0, 0))
+        CpuInitializer::new(ScryptParams::new(n, 1, 1))
             .initialize_to(&mut expected, &[0u8; 32], indices, None)
             .unwrap();
 
@@ -436,7 +436,7 @@ mod tests {
         let mut expected =
             Vec::<u8>::with_capacity(usize::try_from(indices.end - indices.start).unwrap());
 
-        CpuInitializer::new(ScryptParams::new(n.ilog2() as u8 - 1, 0, 0))
+        CpuInitializer::new(ScryptParams::new(n, 1, 1))
             .initialize_to(&mut expected, &[0u8; 32], indices, None)
             .unwrap();
 
@@ -457,7 +457,7 @@ mod tests {
         let mut expected =
             Vec::<u8>::with_capacity(usize::try_from(indices.end - indices.start).unwrap());
 
-        CpuInitializer::new(ScryptParams::new(12, 0, 0))
+        CpuInitializer::new(ScryptParams::new(8192, 1, 1))
             .initialize_to(&mut expected, commitment, indices, None)
             .unwrap();
 
@@ -485,7 +485,7 @@ mod tests {
         let nonce = opencl_nonce.expect("vrf nonce not found");
 
         let mut label = Vec::<u8>::with_capacity(LABEL_SIZE);
-        let mut cpu_initializer = CpuInitializer::new(ScryptParams::new(n.ilog2() as u8 - 1, 0, 0));
+        let mut cpu_initializer = CpuInitializer::new(ScryptParams::new(n, 1, 1));
         cpu_initializer
             .initialize_to(&mut label, commitment, nonce.index..nonce.index + 1, None)
             .unwrap();
@@ -525,7 +525,7 @@ mod tests {
         let mut expected =
             Vec::<u8>::with_capacity(usize::try_from(indices.end - indices.start).unwrap());
 
-        CpuInitializer::new(ScryptParams::new(N.ilog2() as u8 - 1, 0, 0))
+        CpuInitializer::new(ScryptParams::new(N, 1, 1))
             .initialize_to(&mut expected, &[0u8; 32], indices, None)
             .unwrap();
 

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -171,10 +171,10 @@ async fn main() -> eyre::Result<()> {
             k2: args.post_config.k2,
             k3: args.post_config.k3,
             pow_difficulty: args.post_config.pow_difficulty,
-            scrypt: post::ScryptParams::new(
-                args.post_config.scrypt.n.ilog2() as u8 - 1,
-                args.post_config.scrypt.r.ilog2() as u8,
-                args.post_config.scrypt.p.ilog2() as u8,
+            scrypt: post::config::ScryptParams::new(
+                args.post_config.scrypt.n,
+                args.post_config.scrypt.r,
+                args.post_config.scrypt.p,
             ),
         },
         args.post_settings.nonces,

--- a/service/tests/test_client.rs
+++ b/service/tests/test_client.rs
@@ -229,7 +229,7 @@ async fn test_get_metadata(#[case] vrf_difficulty: Option<[u8; 32]>) {
         k2: 32,
         k3: 10,
         pow_difficulty: [0xFF; 32],
-        scrypt: post::ScryptParams::new(0, 0, 0),
+        scrypt: post::config::ScryptParams::new(2, 1, 1),
     };
 
     let metadata = CpuInitializer::new(cfg.scrypt)

--- a/service/tests/test_service.rs
+++ b/service/tests/test_service.rs
@@ -1,10 +1,10 @@
 use std::{thread::sleep, time::Duration};
 
 use post::{
+    config::ScryptParams,
     initialize::{CpuInitializer, Initialize},
     metadata::ProofMetadata,
     pow::randomx::RandomXFlag,
-    ScryptParams,
 };
 use post_service::{client::PostService, service::ProofGenState};
 
@@ -19,7 +19,7 @@ fn test_generate_and_verify() {
         k2: 4,
         k3: 4,
         pow_difficulty: [0xFF; 32],
-        scrypt: ScryptParams::new(0, 0, 0),
+        scrypt: ScryptParams::new(2, 1, 1),
     };
 
     let metadata = CpuInitializer::new(cfg.scrypt)
@@ -65,7 +65,7 @@ fn reject_invalid_challenge() {
         k2: 4,
         k3: 4,
         pow_difficulty: [0xFF; 32],
-        scrypt: ScryptParams::new(0, 0, 0),
+        scrypt: ScryptParams::new(2, 1, 1),
     };
 
     CpuInitializer::new(cfg.scrypt)
@@ -103,7 +103,7 @@ fn cannot_run_parallel_proof_gens() {
         k2: 4,
         k3: 4,
         pow_difficulty: [0xFF; 32],
-        scrypt: ScryptParams::new(0, 0, 0),
+        scrypt: ScryptParams::new(2, 1, 1),
     };
 
     CpuInitializer::new(cfg.scrypt)

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,5 +11,33 @@ pub struct Config {
     /// `pow` for [Proof][crate::prove::Proof].
     pub pow_difficulty: [u8; 32],
     /// Scrypt paramters for initilizing labels
-    pub scrypt: scrypt_jane::scrypt::ScryptParams,
+    pub scrypt: ScryptParams,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct ScryptParams {
+    pub n: usize,
+    pub r: usize,
+    pub p: usize,
+}
+
+impl ScryptParams {
+    pub fn new(n: usize, r: usize, p: usize) -> Self {
+        assert!(n >= 2);
+        assert!(n.is_power_of_two());
+        assert!(r.is_power_of_two());
+        assert!(p.is_power_of_two());
+        Self { n, r, p }
+    }
+}
+
+impl From<ScryptParams> for scrypt_jane::scrypt::ScryptParams {
+    fn from(params: ScryptParams) -> Self {
+        Self::new(
+            params.n.ilog2() as u8 - 1,
+            params.r.ilog2() as u8,
+            params.p.ilog2() as u8,
+        )
+    }
 }

--- a/src/initialize.rs
+++ b/src/initialize.rs
@@ -8,9 +8,9 @@ use std::{
 
 use mockall::automock;
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
-use scrypt_jane::scrypt::{scrypt, ScryptParams};
+use scrypt_jane::scrypt::scrypt;
 
-use crate::metadata::PostMetadata;
+use crate::{config::ScryptParams, metadata::PostMetadata};
 
 pub const LABEL_SIZE: usize = 16;
 pub const ENTIRE_LABEL_SIZE: usize = 32;
@@ -115,7 +115,7 @@ impl Initialize for CpuInitializer {
                 let mut scrypt_data = [0u8; 72];
                 scrypt_data[0..32].copy_from_slice(commitment);
                 scrypt_data[32..40].copy_from_slice(&index.to_le_bytes());
-                scrypt(&scrypt_data, &[], self.scrypt_params, &mut label);
+                scrypt(&scrypt_data, &[], self.scrypt_params.into(), &mut label);
                 label
             })
             .collect::<Vec<_>>();
@@ -168,7 +168,7 @@ mod tests {
 
         let mut pos_file = tempfile::tempfile().unwrap();
         let commitment = [0u8; 32];
-        let scrypt_params = ScryptParams::new(1, 0, 0);
+        let scrypt_params = ScryptParams::new(4, 1, 1);
         CpuInitializer::new(scrypt_params)
             .initialize_to(&mut pos_file, &commitment, labels, None)
             .unwrap();
@@ -178,7 +178,7 @@ mod tests {
 
     #[test]
     fn test_initialize_fits_in_single_file() {
-        let scrypt_params = ScryptParams::new(1, 0, 0);
+        let scrypt_params = ScryptParams::new(4, 1, 1);
         let data_dir = tempfile::tempdir().unwrap();
         let data_path = data_dir.path();
         CpuInitializer::new(scrypt_params)
@@ -201,7 +201,7 @@ mod tests {
 
     #[test]
     fn test_initialize_returns_metadata() {
-        let scrypt_params = ScryptParams::new(1, 0, 0);
+        let scrypt_params = ScryptParams::new(4, 1, 1);
         let data_dir = tempfile::tempdir().unwrap();
         let node_id = rand::random::<[u8; 32]>();
         let commitment_atx_id = rand::random::<[u8; 32]>();
@@ -228,7 +228,7 @@ mod tests {
 
     #[test]
     fn test_initialize_split_many_files() {
-        let scrypt_params = ScryptParams::new(1, 0, 0);
+        let scrypt_params = ScryptParams::new(4, 1, 1);
         let data_dir = tempfile::tempdir().unwrap();
         let data_path = data_dir.path();
         CpuInitializer::new(scrypt_params)
@@ -262,7 +262,7 @@ mod tests {
 
     #[test]
     fn initialization_to_many_files_gives_same_result_as_single_file() {
-        let scrypt_params = ScryptParams::new(1, 0, 0);
+        let scrypt_params = ScryptParams::new(4, 1, 1);
         let data_dir = tempfile::tempdir().unwrap();
         let data_path = data_dir.path();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,3 @@ pub mod prove;
 mod random_values_gen;
 pub mod reader;
 pub mod verification;
-
-// Reexport scrypt-jane params
-pub use scrypt_jane::scrypt::ScryptParams;

--- a/src/pos_verification.rs
+++ b/src/pos_verification.rs
@@ -5,9 +5,9 @@ use std::{io::Read, io::Seek, path::Path};
 use itertools::Itertools;
 use rand::seq::IteratorRandom;
 use rayon::prelude::{ParallelBridge, ParallelIterator};
-use scrypt_jane::scrypt::ScryptParams;
 
 use crate::{
+    config::ScryptParams,
     initialize::{calc_commitment, CpuInitializer, Initialize},
     metadata,
 };

--- a/src/prove.rs
+++ b/src/prove.rs
@@ -354,10 +354,11 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{compression::decompress_indexes, difficulty::proving_difficulty};
+    use crate::{
+        compression::decompress_indexes, config::ScryptParams, difficulty::proving_difficulty,
+    };
     use mockall::predicate::{always, eq};
     use rand::{thread_rng, RngCore};
-    use scrypt_jane::scrypt::ScryptParams;
     use std::{collections::HashMap, iter::repeat};
 
     #[test]
@@ -388,7 +389,7 @@ mod tests {
             k2: 300,
             k3: 65,
             pow_difficulty: [0xFF; 32],
-            scrypt: ScryptParams::new(1, 0, 0),
+            scrypt: ScryptParams::new(2, 1, 1),
         };
         let params = ProvingParams::new(&meta, &cfg).unwrap();
         let mut pow_prover = pow::MockProver::new();
@@ -424,7 +425,7 @@ mod tests {
             k2: 300,
             k3: 65,
             pow_difficulty: [0xFF; 32],
-            scrypt: ScryptParams::new(1, 0, 0),
+            scrypt: ScryptParams::new(4, 1, 1),
         };
         let mut pow_prover = pow::MockProver::new();
         pow_prover
@@ -443,7 +444,7 @@ mod tests {
             k2: 32,
             k3: 10,
             pow_difficulty: [0x0F; 32],
-            scrypt: ScryptParams::new(2, 0, 0),
+            scrypt: ScryptParams::new(2, 1, 1),
         };
         let metadata = PostMetadata {
             num_units: 1,

--- a/src/verification.rs
+++ b/src/verification.rs
@@ -40,12 +40,11 @@ use std::cmp::Ordering;
 use cipher::BlockEncrypt;
 use itertools::Itertools;
 use primitive_types::U256;
-use scrypt_jane::scrypt::ScryptParams;
 
 use crate::{
     cipher::AesCipher,
     compression::{decompress_indexes, required_bits},
-    config::Config,
+    config::{Config, ScryptParams},
     difficulty::proving_difficulty,
     initialize::{calc_commitment, generate_label},
     metadata::ProofMetadata,
@@ -239,10 +238,11 @@ fn expected_indices_bytes(required_bits: usize, k2: u32) -> usize {
 mod tests {
     use std::borrow::Cow;
 
-    use scrypt_jane::scrypt::ScryptParams;
-
     use crate::{
-        config::Config, metadata::ProofMetadata, pow::MockPowVerifier, prove::Proof,
+        config::{Config, ScryptParams},
+        metadata::ProofMetadata,
+        pow::MockPowVerifier,
+        prove::Proof,
         verification::Error,
     };
 
@@ -268,7 +268,7 @@ mod tests {
             k2: 3,
             k3: 3,
             pow_difficulty: [0xFF; 32],
-            scrypt: ScryptParams::new(1, 0, 0),
+            scrypt: ScryptParams::new(2, 1, 1),
         };
 
         let fake_metadata = ProofMetadata {
@@ -302,7 +302,7 @@ mod tests {
             k2: 10,
             k3: 10,
             pow_difficulty: [0xFF; 32],
-            scrypt: ScryptParams::new(1, 0, 0),
+            scrypt: ScryptParams::new(4, 1, 1),
         };
 
         let fake_metadata = ProofMetadata {
@@ -366,7 +366,7 @@ mod tests {
             k2: 0,
             k3: 0,
             pow_difficulty: [0xFF; 32],
-            scrypt: ScryptParams::new(2, 0, 0),
+            scrypt: ScryptParams::new(2, 1, 1),
         };
         let metadata = ProofMetadata {
             node_id: [0u8; 32],

--- a/tests/generate_and_verify.rs
+++ b/tests/generate_and_verify.rs
@@ -1,13 +1,13 @@
 use std::sync::atomic::AtomicBool;
 
 use post::{
+    config::ScryptParams,
     initialize::{CpuInitializer, Initialize},
     metadata::ProofMetadata,
     pow::randomx::{PoW, RandomXFlag},
     prove::generate_proof,
     verification::{Verifier, VerifyingParams},
 };
-use scrypt_jane::scrypt::ScryptParams;
 use tempfile::tempdir;
 
 #[test]
@@ -22,7 +22,7 @@ fn test_generate_and_verify() {
         k2: 32,
         k3: 10,
         pow_difficulty: [0xFF; 32],
-        scrypt: ScryptParams::new(0, 0, 0),
+        scrypt: ScryptParams::new(2, 1, 1),
     };
 
     let metadata = CpuInitializer::new(cfg.scrypt)
@@ -79,7 +79,7 @@ fn test_generate_and_verify_difficulty_msb_not_zero() {
         k2: 30,
         k3: 30,
         pow_difficulty: [0xFF; 32],
-        scrypt: ScryptParams::new(0, 0, 0),
+        scrypt: ScryptParams::new(2, 1, 1),
     };
 
     let metadata = CpuInitializer::new(cfg.scrypt)

--- a/tests/initialize_and_verify.rs
+++ b/tests/initialize_and_verify.rs
@@ -1,10 +1,11 @@
 use std::io::Write;
 
 use post::{
+    config::ScryptParams,
     initialize::{CpuInitializer, Initialize},
     pos_verification::verify_files,
 };
-use scrypt_jane::scrypt::ScryptParams;
+
 use tempfile::tempdir;
 
 #[test]
@@ -17,7 +18,7 @@ fn test_generate_and_verify() {
         k2: 32,
         k3: 10,
         pow_difficulty: [0xFF; 32],
-        scrypt: ScryptParams::new(0, 0, 0),
+        scrypt: ScryptParams::new(2, 1, 1),
     };
 
     CpuInitializer::new(cfg.scrypt)
@@ -30,7 +31,7 @@ fn test_generate_and_verify() {
     verify_files(datadir.path(), 1.0, Some(0), Some(1), cfg.scrypt).unwrap();
 
     // Try verification with wrong scrypt params
-    let wrong_scrypt = ScryptParams::new(2, 0, 0);
+    let wrong_scrypt = ScryptParams::new(4, 1, 1);
     assert!(verify_files(datadir.path(), 100.0, None, None, wrong_scrypt).is_err());
     assert!(verify_files(datadir.path(), 1.0, None, None, wrong_scrypt).is_err());
     assert!(verify_files(datadir.path(), 100.0, Some(0), Some(0), wrong_scrypt).is_err());


### PR DESCRIPTION
Change to use scrypt parameters in the form of N, R, and P instead of their factors for a nicer UX.

Note: this is a breaking change in FFI (post repo needs to be updated).