### PR TITLE
Bump randomx-rs, don't override Mac SDK with old 12.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,26 +67,17 @@ jobs:
         run: cargo test --all-features --release
         env:
           RUSTFLAGS: ${{ matrix.rustflags }}
-          # https://github.com/tevador/RandomX/issues/262
-          # https://github.com/tari-project/randomx-rs/issues/48
-          SDKROOT: "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk"
 
       - name: Test scrypt-ocl crate
         if: matrix.os != 'windows-2019'
         run: cargo test -p scrypt-ocl --all-features --release -- --test-threads=1
         env:
           RUSTFLAGS: ${{ matrix.rustflags }}
-          # https://github.com/tevador/RandomX/issues/262
-          # https://github.com/tari-project/randomx-rs/issues/48
-          SDKROOT: "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk"
 
       - name: Test ffi crate
         run: cargo test -p post-cbindings --all-features --release -- --test-threads=1
         env:
           RUSTFLAGS: ${{ matrix.rustflags }}
-          # https://github.com/tevador/RandomX/issues/262
-          # https://github.com/tari-project/randomx-rs/issues/48
-          SDKROOT: "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk"
 
   fmt:
     name: Rustfmt
@@ -218,9 +209,6 @@ jobs:
         run: cargo build -p post-cbindings --profile release-clib
         env:
           RUSTFLAGS: ${{ matrix.rustflags }}
-          # https://github.com/tevador/RandomX/issues/262
-          # https://github.com/tari-project/randomx-rs/issues/48
-          SDKROOT: "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk"
       - name: Archive production artifacts
         uses: actions/upload-artifact@v3
         with:
@@ -235,9 +223,6 @@ jobs:
         run: cargo build -p profiler --release
         env:
           RUSTFLAGS: ${{ matrix.rustflags }}
-          # https://github.com/tevador/RandomX/issues/262
-          # https://github.com/tari-project/randomx-rs/issues/48
-          SDKROOT: "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk"
       - name: Archive profiler artifacts
         uses: actions/upload-artifact@v3
         with:
@@ -253,7 +238,6 @@ jobs:
         run: cargo build -p service --release
         env:
           RUSTFLAGS: ${{ matrix.rustflags }}
-          SDKROOT: "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk"
       - name: Archive service artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2643,8 +2643,8 @@ dependencies = [
 
 [[package]]
 name = "randomx-rs"
-version = "1.1.15"
-source = "git+https://github.com/spacemeshos/randomx-rs?rev=6f2bf32af7219a5f9ae929c3020242ecc7c6dd6a#6f2bf32af7219a5f9ae929c3020242ecc7c6dd6a"
+version = "1.3.0"
+source = "git+https://github.com/spacemeshos/randomx-rs?rev=d46bcd90e09428883e253b8203d6b311b0a07b91#d46bcd90e09428883e253b8203d6b311b0a07b91"
 dependencies = [
  "bitflags 2.4.0",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ bitvec = "1.0.1"
 rayon = "1.6.1"
 rand = "0.8.5"
 log = "0.4.17"
-randomx-rs = { git = "https://github.com/spacemeshos/randomx-rs", rev = "6f2bf32af7219a5f9ae929c3020242ecc7c6dd6a" }
+randomx-rs = { git = "https://github.com/spacemeshos/randomx-rs", rev = "d46bcd90e09428883e253b8203d6b311b0a07b91" }
 
 
 primitive-types = "0.12.1"


### PR DESCRIPTION
The new randomx-rs version uses a newer RandomX v1.2.1, that fixed https://github.com/tevador/RandomX/issues/262. We don't need to build using an older Mac SDK anymore.