### PR TITLE
Readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,3 @@ Includes:
 ### Randomx-rs
 [RandomX](https://github.com/tevador/randomx), that [randomx-rs](https://github.com/spacemeshos/randomx-rs) depends on, requires **cmake**. Follow [these instructions](https://github.com/spacemeshos/randomx-rs#build-dependencies) to install it.
 
-## Troubleshooting
-### Crash on Mac arm64
-RandomX is known to misbehave, or even crash on arm64 Macs when using JIT. See this issue for details: https://github.com/tevador/RandomX/issues/262.
-
-The mitigation is to use an older Mac SDK (i.e. v12) to build. This repository CI uses **MacOSX12.3.sdk** by overriding `SDKROOT` during build.


### PR DESCRIPTION
Readme still contains troubleshooting information for Apple M1 but that is not longer necessary as of #152 