### PR TITLE
Use the recommented rustsec/audit-check action

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -11,7 +11,7 @@ jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/audit-check@v1
+      - uses: actions/checkout@v3
+      - uses: rustsec/audit-check@v1.4.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The https://github.com/actions-rs/audit-check action is archived.

The https://github.com/rustsec/audit-check is recommended on https://crates.io/crates/cargo-audit