### PR TITLE
Build with rust 1.74.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.74.1
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --workspace --all-features
 
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.74.1
       - if: matrix.runner == 'self-hosted-linux-intel'
         run: sudo apt-get update && sudo apt-get install -y libpocl2 pocl-opencl-icd ocl-icd-opencl-dev
         name: Install dependencies for testing openCL on Linux
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.74.1
         with:
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
@@ -122,7 +122,7 @@ jobs:
         with:
           submodules: true
       - name: Install stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.74.1
         with:
           components: llvm-tools-preview
       - name: cargo install cargo-llvm-cov
@@ -181,7 +181,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.74.1
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ join( matrix.os, '-' ) }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,7 +510,7 @@ dependencies = [
 
 [[package]]
 name = "certifier"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "axum 0.7.1",
  "axum-prometheus",
@@ -1681,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "initializer"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "base64 0.21.5",
  "clap 4.4.10",
@@ -2469,7 +2469,7 @@ checksum = "3bccab0e7fd7cc19f820a1c8c91720af652d0c88dc9664dd72aef2614f04af3b"
 
 [[package]]
 name = "post-cbindings"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "cbindgen",
  "log",
@@ -2480,7 +2480,7 @@ dependencies = [
 
 [[package]]
 name = "post-rs"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "aes",
  "bitvec",
@@ -2615,7 +2615,7 @@ dependencies = [
 
 [[package]]
 name = "profiler"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "clap 4.4.10",
  "env_logger",
@@ -3200,7 +3200,7 @@ dependencies = [
 
 [[package]]
 name = "scrypt-ocl"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "log",
  "ocl",
@@ -3343,7 +3343,7 @@ dependencies = [
 
 [[package]]
 name = "service"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "async-stream",
  "clap 4.4.10",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 [package]
 name = "post-rs"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 
 [lib]

--- a/certifier/Cargo.toml
+++ b/certifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "certifier"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 
 [dependencies]

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "post-cbindings"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 
 

--- a/initializer/Cargo.toml
+++ b/initializer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "initializer"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/profiler/Cargo.toml
+++ b/profiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profiler"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 
 [dependencies]

--- a/scrypt-ocl/Cargo.toml
+++ b/scrypt-ocl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrypt-ocl"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 
 [dependencies]

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "service"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
Downgrade Rust to 1.74.1. The libpost.so from the recent release v0.6.3 crashes in one unit test when called from Go on Linux. The same code works fine when built with Rust 1.74.1.