### PR TITLE
Expose version() in C API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,7 +510,7 @@ dependencies = [
 
 [[package]]
 name = "certifier"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "axum 0.7.1",
  "axum-prometheus",
@@ -1681,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "initializer"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "base64 0.21.5",
  "clap 4.4.10",
@@ -2469,7 +2469,7 @@ checksum = "3bccab0e7fd7cc19f820a1c8c91720af652d0c88dc9664dd72aef2614f04af3b"
 
 [[package]]
 name = "post-cbindings"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "cbindgen",
  "log",
@@ -2480,7 +2480,7 @@ dependencies = [
 
 [[package]]
 name = "post-rs"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "aes",
  "bitvec",
@@ -2615,7 +2615,7 @@ dependencies = [
 
 [[package]]
 name = "profiler"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "clap 4.4.10",
  "env_logger",
@@ -3200,7 +3200,7 @@ dependencies = [
 
 [[package]]
 name = "scrypt-ocl"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "log",
  "ocl",
@@ -3343,7 +3343,7 @@ dependencies = [
 
 [[package]]
 name = "service"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "async-stream",
  "clap 4.4.10",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 [package]
 name = "post-rs"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2021"
 
 [lib]

--- a/certifier/Cargo.toml
+++ b/certifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "certifier"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2021"
 
 [dependencies]

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "post-cbindings"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2021"
 
 

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1,6 +1,7 @@
 mod initialization;
 mod log;
 mod post_impl;
+mod version;
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]

--- a/ffi/src/version.rs
+++ b/ffi/src/version.rs
@@ -1,0 +1,17 @@
+use std::ffi::{c_char, CStr};
+
+const VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), "\0");
+
+#[no_mangle]
+pub extern "C" fn version() -> *const c_char {
+    unsafe { CStr::from_bytes_with_nul_unchecked(VERSION.as_bytes()) }.as_ptr()
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_version() {
+        let version = unsafe { std::ffi::CStr::from_ptr(super::version()) };
+        assert_eq!(version.to_str().unwrap(), env!("CARGO_PKG_VERSION"));
+    }
+}

--- a/initializer/Cargo.toml
+++ b/initializer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "initializer"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/profiler/Cargo.toml
+++ b/profiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profiler"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2021"
 
 [dependencies]

--- a/scrypt-ocl/Cargo.toml
+++ b/scrypt-ocl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrypt-ocl"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2021"
 
 [dependencies]

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "service"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
It returns the version of the `post-cbindings` module under (as in `ffi/Cargo.toml`).