### PR TITLE
Don't keep open postfiles when proving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,7 +510,7 @@ dependencies = [
 
 [[package]]
 name = "certifier"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "axum 0.7.1",
  "axum-prometheus",
@@ -1681,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "initializer"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "base64 0.21.5",
  "clap 4.4.10",
@@ -2469,7 +2469,7 @@ checksum = "3bccab0e7fd7cc19f820a1c8c91720af652d0c88dc9664dd72aef2614f04af3b"
 
 [[package]]
 name = "post-cbindings"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "cbindgen",
  "log",
@@ -2480,7 +2480,7 @@ dependencies = [
 
 [[package]]
 name = "post-rs"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "aes",
  "bitvec",
@@ -2615,7 +2615,7 @@ dependencies = [
 
 [[package]]
 name = "profiler"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "clap 4.4.10",
  "env_logger",
@@ -3200,7 +3200,7 @@ dependencies = [
 
 [[package]]
 name = "scrypt-ocl"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "log",
  "ocl",
@@ -3343,7 +3343,7 @@ dependencies = [
 
 [[package]]
 name = "service"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "async-stream",
  "clap 4.4.10",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 [package]
 name = "post-rs"
-version = "0.6.5"
+version = "0.6.6"
 edition = "2021"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,3 +71,7 @@ inherits = "release"
 strip = true
 lto = true
 rpath = true
+
+[profile.dev-clib]
+inherits = "dev"
+rpath = true

--- a/certifier/Cargo.toml
+++ b/certifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "certifier"
-version = "0.6.5"
+version = "0.6.6"
 edition = "2021"
 
 [dependencies]

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "post-cbindings"
-version = "0.6.5"
+version = "0.6.6"
 edition = "2021"
 
 

--- a/initializer/Cargo.toml
+++ b/initializer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "initializer"
-version = "0.6.5"
+version = "0.6.6"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/profiler/Cargo.toml
+++ b/profiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profiler"
-version = "0.6.5"
+version = "0.6.6"
 edition = "2021"
 
 [dependencies]

--- a/profiler/src/main.rs
+++ b/profiler/src/main.rs
@@ -14,6 +14,7 @@ use eyre::Context;
 use post::{
     pow::{self, randomx, Prover as PowProver},
     prove::{Prover, Prover8_56, ProvingParams},
+    reader::BatchingReader,
 };
 use rand::RngCore;
 use rayon::prelude::{ParallelBridge, ParallelIterator};
@@ -227,7 +228,7 @@ fn proving(args: ProvingArgs) -> eyre::Result<()> {
 
     while total_time < Duration::from_secs(args.duration) {
         let file = util::open_without_cache(&file_path)?;
-        let reader = post::reader::read_from(BufReader::new(file), batch_size, total_size, None);
+        let reader = BatchingReader::new(BufReader::new(file), 0, batch_size, total_size);
         let start = time::Instant::now();
         pool.install(|| {
             reader.par_bridge().for_each(|batch| {

--- a/scrypt-ocl/Cargo.toml
+++ b/scrypt-ocl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrypt-ocl"
-version = "0.6.5"
+version = "0.6.6"
 edition = "2021"
 
 [dependencies]

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "service"
-version = "0.6.5"
+version = "0.6.6"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
Closes #179

Open postdata binary files lazily, when starting reading from them. The files are automatically closed when finished to the end.