### PR TITLE
Remove --labels-per-unit from service CLI

### DIFF
--- a/service/tests/test_client.rs
+++ b/service/tests/test_client.rs
@@ -103,7 +103,7 @@ async fn test_gen_proof_finished() {
 
     let mut service = MockPostService::new();
     service.expect_gen_proof().returning(move |c| {
-        assert_eq!(c.as_slice(), challenge);
+        assert_eq!(c, challenge);
         Ok(ProofGenState::Finished {
             proof: Proof {
                 nonce: 1,
@@ -121,9 +121,7 @@ async fn test_gen_proof_finished() {
         nonce: Some(12),
         ..Default::default()
     };
-    service
-        .expect_get_metadata()
-        .returning(move || Ok(post_metadata));
+    service.expect_get_metadata().return_const(post_metadata);
     // First try passes
     service
         .expect_verify_proof()
@@ -229,14 +227,10 @@ async fn test_get_metadata(#[case] vrf_difficulty: Option<[u8; 32]>) {
         k2: 32,
         pow_difficulty: [0xFF; 32],
     };
-    let init_cfg = post::config::InitConfig {
-        min_num_units: 1,
-        max_num_units: 1000,
-        labels_per_unit: 256 * 16,
-        scrypt: post::config::ScryptParams::new(2, 1, 1),
-    };
 
-    let metadata = CpuInitializer::new(init_cfg.scrypt)
+    let scrypt = post::config::ScryptParams::new(2, 1, 1);
+
+    let metadata = CpuInitializer::new(scrypt)
         .initialize(
             datadir.path(),
             &[77; 32],
@@ -253,7 +247,7 @@ async fn test_get_metadata(#[case] vrf_difficulty: Option<[u8; 32]>) {
     let service = post_service::service::PostService::new(
         datadir.path().into(),
         cfg,
-        init_cfg,
+        scrypt,
         16,
         post::config::Cores::Any(1),
         post::pow::randomx::RandomXFlag::get_recommended_flags(),

--- a/service/tests/test_operator.rs
+++ b/service/tests/test_operator.rs
@@ -24,23 +24,10 @@ async fn test_gen_proof_in_progress() {
         k2: 12,
         pow_difficulty: [0xFF; 32],
     };
-    let init_cfg = post::config::InitConfig {
-        min_num_units: 1,
-        max_num_units: 100,
-        labels_per_unit: 2560,
-        scrypt: post::config::ScryptParams::new(2, 1, 1),
-    };
 
-    CpuInitializer::new(init_cfg.scrypt)
-        .initialize(
-            datadir.path(),
-            &[0xBE; 32],
-            &[0xCE; 32],
-            init_cfg.labels_per_unit,
-            4,
-            256,
-            None,
-        )
+    let scrypt = post::config::ScryptParams::new(2, 1, 1);
+    CpuInitializer::new(scrypt)
+        .initialize(datadir.path(), &[0xBE; 32], &[0xCE; 32], 256, 4, 256, None)
         .unwrap();
 
     let pow_flags = RandomXFlag::get_recommended_flags();
@@ -49,7 +36,7 @@ async fn test_gen_proof_in_progress() {
         post_service::service::PostService::new(
             datadir.into_path(),
             cfg,
-            init_cfg,
+            scrypt,
             16,
             post::config::Cores::Any(1),
             pow_flags,

--- a/service/tests/test_service.rs
+++ b/service/tests/test_service.rs
@@ -1,9 +1,8 @@
 use std::{thread::sleep, time::Duration};
 
 use post::{
-    config::{InitConfig, ProofConfig, ScryptParams},
+    config::{ProofConfig, ScryptParams},
     initialize::{CpuInitializer, Initialize},
-    metadata::ProofMetadata,
     pow::randomx::RandomXFlag,
 };
 use post_service::{client::PostService, service::ProofGenState};
@@ -18,23 +17,10 @@ fn test_generate_and_verify() {
         k2: 4,
         pow_difficulty: [0xFF; 32],
     };
-    let init_cfg = InitConfig {
-        min_num_units: 1,
-        max_num_units: 1000,
-        labels_per_unit: 256,
-        scrypt: ScryptParams::new(2, 1, 1),
-    };
+    let scrypt = ScryptParams::new(2, 1, 1);
 
-    let metadata = CpuInitializer::new(init_cfg.scrypt)
-        .initialize(
-            datadir.path(),
-            &[0xBE; 32],
-            &[0xCE; 32],
-            init_cfg.labels_per_unit,
-            4,
-            init_cfg.labels_per_unit,
-            None,
-        )
+    CpuInitializer::new(scrypt)
+        .initialize(datadir.path(), &[0xBE; 32], &[0xCE; 32], 156, 4, 256, None)
         .unwrap();
 
     let pow_flags = RandomXFlag::get_recommended_flags();
@@ -43,23 +29,23 @@ fn test_generate_and_verify() {
     let service = post_service::service::PostService::new(
         datadir.into_path(),
         cfg,
-        init_cfg,
+        scrypt,
         16,
         post::config::Cores::Any(1),
         pow_flags,
     )
     .unwrap();
 
-    let (proof, metadata) = loop {
-        if let ProofGenState::Finished { proof } = service.gen_proof(vec![0xCA; 32]).unwrap() {
-            break (proof, metadata);
+    let proof = loop {
+        if let ProofGenState::Finished { proof } = service.gen_proof(&[0xCA; 32]).unwrap() {
+            break proof;
         }
         sleep(Duration::from_millis(10));
     };
 
     // Verify the proof
     service
-        .verify_proof(&proof, &ProofMetadata::new(metadata, [0xCA; 32]))
+        .verify_proof(&proof, &[0xCA; 32])
         .expect("proof should be valid");
 }
 
@@ -73,36 +59,23 @@ fn reject_invalid_challenge() {
         k2: 4,
         pow_difficulty: [0xFF; 32],
     };
-    let init_cfg = InitConfig {
-        min_num_units: 1,
-        max_num_units: 1000,
-        labels_per_unit: 256,
-        scrypt: ScryptParams::new(2, 1, 1),
-    };
+    let scrypt = ScryptParams::new(2, 1, 1);
 
-    CpuInitializer::new(init_cfg.scrypt)
-        .initialize(
-            datadir.path(),
-            &[0xBE; 32],
-            &[0xCE; 32],
-            init_cfg.labels_per_unit,
-            4,
-            init_cfg.labels_per_unit,
-            None,
-        )
+    CpuInitializer::new(scrypt)
+        .initialize(datadir.path(), &[0xBE; 32], &[0xCE; 32], 256, 4, 256, None)
         .unwrap();
 
     // Generate a proof
     let service = post_service::service::PostService::new(
         datadir.into_path(),
         cfg,
-        init_cfg,
+        scrypt,
         16,
         post::config::Cores::Any(1),
         RandomXFlag::get_recommended_flags(),
     )
     .unwrap();
-    assert!(service.gen_proof(vec![0xCA; 5]).is_err());
+    assert!(service.gen_proof(&[0xCA; 5]).is_err());
 }
 
 #[test]
@@ -115,40 +88,27 @@ fn cannot_run_parallel_proof_gens() {
         k2: 4,
         pow_difficulty: [0xFF; 32],
     };
-    let init_cfg = InitConfig {
-        min_num_units: 1,
-        max_num_units: 1000,
-        labels_per_unit: 256,
-        scrypt: ScryptParams::new(2, 1, 1),
-    };
+    let scrypt = ScryptParams::new(2, 1, 1);
 
-    CpuInitializer::new(init_cfg.scrypt)
-        .initialize(
-            datadir.path(),
-            &[0xBE; 32],
-            &[0xCE; 32],
-            init_cfg.labels_per_unit,
-            4,
-            init_cfg.labels_per_unit,
-            None,
-        )
+    CpuInitializer::new(scrypt)
+        .initialize(datadir.path(), &[0xBE; 32], &[0xCE; 32], 256, 4, 256, None)
         .unwrap();
 
     // Generate a proof
     let service = post_service::service::PostService::new(
         datadir.into_path(),
         cfg,
-        init_cfg,
+        scrypt,
         16,
         post::config::Cores::Any(1),
         RandomXFlag::get_recommended_flags(),
     )
     .unwrap();
 
-    let result = service.gen_proof(vec![0xAA; 32]);
+    let result = service.gen_proof(&[0xAA; 32]);
     assert!(matches!(result, Ok(ProofGenState::InProgress)));
     // Try to generate another proof with a different challenge
-    assert!(service.gen_proof(vec![0xBB; 5]).is_err());
+    assert!(service.gen_proof(&[0xBB; 5]).is_err());
     // Try again with the same challenge
     assert!(matches!(result, Ok(ProofGenState::InProgress)));
 }


### PR DESCRIPTION
This can and should be read from the postdata_metadata.json

Changes:
- removed --labels-per-unit, it is now read from postdata_metadata.json
- read POST metadata at service start
- verify num units in metadata against --min and --max
- simply `PostService` API