### PR TITLE
Fix UT flaky due to parallelism

### DIFF
--- a/src/pow/randomx.rs
+++ b/src/pow/randomx.rs
@@ -151,8 +151,12 @@ mod tests {
         ];
         let prover = PoW::new(RandomXFlag::get_recommended_flags()).unwrap();
 
-        let pow = prover
-            .prove(nonce, challenge, difficulty, &[1; 32])
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(1)
+            .build()
+            .unwrap();
+        let pow = pool
+            .install(|| prover.prove(nonce, challenge, difficulty, &[1; 32]))
             .unwrap();
         prover
             .verify(pow, nonce, challenge, difficulty, &[2; 32])


### PR DESCRIPTION
The test is flaky because the PoW prover runs in parallel and might find a different nonce every run. It might find a nonce that works for a different miner too because the difficulty is easy.

Proving with a single thread removes randomness and fixes the test.