### PR TITLE
Configure HTTP2 keepalive for the GRPC connection in service

### DIFF
--- a/service/src/client.rs
+++ b/service/src/client.rs
@@ -68,7 +68,9 @@ impl<S: PostService> ServiceClient<S> {
         tls: Option<(Option<String>, Certificate, Identity)>,
         service: S,
     ) -> eyre::Result<Self> {
-        let endpoint = Channel::builder(address.parse()?);
+        let endpoint = Channel::builder(address.parse()?)
+            .keep_alive_timeout(Duration::from_secs(20))
+            .http2_keep_alive_interval(Duration::from_secs(60));
         let endpoint = match tls {
             Some((domain, cert, identity)) => {
                 let domain = match domain {


### PR DESCRIPTION
related: https://github.com/spacemeshos/go-spacemesh/issues/5715