### PR TITLE
Support for certificates with expiration date

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,6 +320,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,8 +496,7 @@ version = "0.7.4"
 dependencies = [
  "axum 0.7.4",
  "axum-prometheus",
- "base64",
- "chrono",
+ "base64 0.22.0",
  "clap",
  "config",
  "duration-str",
@@ -537,10 +542,8 @@ checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "js-sys",
  "num-traits 0.2.17",
  "serde",
- "wasm-bindgen",
  "windows-targets 0.52.0",
 ]
 
@@ -984,7 +987,6 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8bb6a301a95ba86fa0ebaf71d49ae4838c51f8b84cb88ed140dfb66452bb3c4"
 dependencies = [
- "chrono",
  "nom",
  "rust_decimal",
  "serde",
@@ -1679,7 +1681,7 @@ dependencies = [
 name = "initializer"
 version = "0.7.4"
 dependencies = [
- "base64",
+ "base64 0.22.0",
  "clap",
  "env_logger",
  "eyre",
@@ -1877,7 +1879,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bf4e7146e30ad172c42c39b3246864bd2d3c6396780711a1baf749cfe423e21"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "hyper 0.14.28",
  "indexmap 2.2.1",
  "ipnet",
@@ -2267,7 +2269,7 @@ version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8fcc794035347fb64beda2d3b462595dd2753e3f268d89c5aae77e8cf2c310"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "serde",
 ]
 
@@ -2874,7 +2876,7 @@ version = "0.11.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bf93c4af7a8bb7d879d51cebe797356ff10ae8516ace542b5182d9dcac10b2"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2952,7 +2954,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bitflags 2.4.2",
  "serde",
  "serde_derive",
@@ -3093,7 +3095,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -3102,7 +3104,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35e4980fa29e4c4b212ffb3db068a564cbf560e51d3944b7c88bd8bf5bec64f4"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "rustls-pki-types",
 ]
 
@@ -3308,7 +3310,7 @@ version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15d167997bd841ec232f5b2b8e0e26606df2e7caa4c31b95ea9ca52b200bd270"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -3837,7 +3839,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum 0.6.20",
- "base64",
+ "base64 0.21.7",
  "bytes",
  "h2 0.3.24",
  "http 0.2.11",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,10 +491,14 @@ dependencies = [
  "axum 0.7.4",
  "axum-prometheus",
  "base64",
+ "chrono",
  "clap",
  "config",
+ "duration-str",
  "ed25519-dalek",
  "hex",
+ "mockall",
+ "parity-scale-codec",
  "post-rs",
  "rand",
  "reqwest",
@@ -527,14 +531,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.33"
+version = "0.4.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
+checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits 0.2.17",
  "serde",
+ "wasm-bindgen",
  "windows-targets 0.52.0",
 ]
 
@@ -971,6 +977,20 @@ name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
+name = "duration-str"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8bb6a301a95ba86fa0ebaf71d49ae4838c51f8b84cb88ed140dfb66452bb3c4"
+dependencies = [
+ "chrono",
+ "nom",
+ "rust_decimal",
+ "serde",
+ "thiserror",
+ "time",
+]
 
 [[package]]
 name = "ed25519"
@@ -3001,6 +3021,16 @@ checksum = "7e2a3bcec1f113553ef1c88aae6c020a369d03d55b58de9869a0908930385091"
 dependencies = [
  "cfg-if",
  "ordered-multimap",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.34.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39449a79f45e8da28c57c341891b69a183044b29518bb8f86dbac9df60bb7df"
+dependencies = [
+ "arrayvec",
+ "num-traits 0.2.17",
 ]
 
 [[package]]

--- a/certifier/Cargo.toml
+++ b/certifier/Cargo.toml
@@ -24,11 +24,13 @@ tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 rand = "0.8.5"
 serde_json = "1.0.108"
-base64 = "0.21.5"
+base64 = "0.22.0"
 axum-prometheus = "0.6.1"
 tower = { version = "0.4.13", features = ["limit"] }
-chrono = { version = "0.4.35", default-features = false, features = ["serde", "now"] }
-duration-str = { version = "0.7.1", default-features = false, features = ["serde", "time", "chrono"] }
+duration-str = { version = "0.7.1", default-features = false, features = [
+    "serde",
+    "time",
+] }
 parity-scale-codec = { version = "3.6.9", features = ["derive", "serde"] }
 mockall = "0.12.1"
 

--- a/certifier/Cargo.toml
+++ b/certifier/Cargo.toml
@@ -27,6 +27,10 @@ serde_json = "1.0.108"
 base64 = "0.21.5"
 axum-prometheus = "0.6.1"
 tower = { version = "0.4.13", features = ["limit"] }
+chrono = { version = "0.4.35", default-features = false, features = ["serde", "now"] }
+duration-str = { version = "0.7.1", default-features = false, features = ["serde", "time", "chrono"] }
+parity-scale-codec = { version = "3.6.9", features = ["derive", "serde"] }
+mockall = "0.12.1"
 
 [dev-dependencies]
 reqwest = { version = "0.11.26", features = ["json"] }

--- a/certifier/README.md
+++ b/certifier/README.md
@@ -28,6 +28,7 @@ The config structure is defined [here](src/configuration.rs). An example config:
 ```yaml
 listen: "127.0.0.1:8080"
 signing_key: <BASE64-encoded ed25519 private key>
+certificate_expiration: 2w
 post_cfg:
   k1: 26
   k2: 37
@@ -47,6 +48,10 @@ randomx_mode: Fast
 ```
 
 Each field can also be provided as env variable prefixed with CERTIFIER. For example, `CERTIFIER_SIGNING_KEY`.
+
+##### Expiring certificates
+The certificates don't expire by default. To create certificates that expire after certain time duration,
+set `certificate_expiration` field in the config. It understands units supported by the [duration_str](https://docs.rs/duration-str/0.7.1/duration_str/index.html) crate (i.e "1d", "2w").
 
 ##### Concurrency limit
 It's important to configure the maximum number of requests that will be processed in parallel.

--- a/certifier/src/certifier.rs
+++ b/certifier/src/certifier.rs
@@ -3,10 +3,12 @@ use std::sync::Arc;
 use axum::http::StatusCode;
 use axum::{extract::State, Json};
 use axum::{routing::post, Router};
-use ed25519_dalek::{Signer, SigningKey};
+use chrono::Utc;
+use ed25519_dalek::{Signature, Signer, SigningKey};
+use parity_scale_codec::{Compact, Decode, Encode};
 use post::config::{InitConfig, ProofConfig};
 use post::pow::randomx::PoW;
-use post::verification::{Mode, Verifier};
+use post::verification::Mode;
 use serde::{Deserialize, Serialize};
 use serde_with::{base64::Base64, serde_as};
 use tracing::instrument;
@@ -20,53 +22,115 @@ pub struct CertifyRequest {
 }
 
 #[serde_as]
-#[derive(Debug, Serialize)]
-struct CertifyResponse {
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CertifyResponse {
+    /// The certificate as scale-encoded `Certificate` struct
     #[serde_as(as = "Base64")]
-    signature: Vec<u8>,
+    pub certificate: Vec<u8>,
+    /// Signature of the certificate
     #[serde_as(as = "Base64")]
-    pub_key: Vec<u8>,
+    pub signature: Vec<u8>,
+    /// The public key of the certifier that signed the certificate
+    #[serde_as(as = "Base64")]
+    pub pub_key: Vec<u8>,
+}
+
+#[derive(Debug, Decode, Encode)]
+pub struct Certificate {
+    // ID of the node being certified
+    pub pub_key: Vec<u8>,
+    /// Unix timestamp
+    pub expiration: Option<Compact<u64>>,
 }
 
 #[instrument(skip(state))]
 async fn certify(
-    State(state): State<Arc<AppState>>,
+    State(state): State<Arc<Certifier>>,
     Json(req): Json<CertifyRequest>,
 ) -> Result<Json<CertifyResponse>, (StatusCode, String)> {
     tracing::debug!("certifying");
 
-    let pub_key = req.metadata.node_id;
-    let my_id = state.signer.verifying_key().to_bytes();
     let s = state.clone();
+    let result = tokio::task::spawn_blocking(move || s.certify(&req.proof, &req.metadata))
+        .await
+        .map_err(|e| {
+            tracing::error!("internal error verifying proof: {e:?}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "error verifying proof".into(),
+            )
+        })?;
 
-    let result = tokio::task::spawn_blocking(move || {
-        s.verifier
-            .verify(&req.proof, &req.metadata, &s.cfg, &s.init_cfg, Mode::All)
-    })
-    .await
-    .map_err(|e| {
-        tracing::error!("internal error verifying proof: {e:?}");
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "error verifying proof".into(),
-        )
-    })?;
-
-    result.map_err(|e| (StatusCode::FORBIDDEN, format!("invalid proof: {e:?}")))?;
-
-    // Sign the nodeID
-    let response = CertifyResponse {
-        signature: state.signer.sign(&pub_key).to_vec(),
-        pub_key: my_id.to_vec(),
-    };
-    Ok(Json(response))
+    match result {
+        Ok(result) => {
+            let response = CertifyResponse {
+                certificate: result.0.to_vec(),
+                signature: result.1.to_vec(),
+                pub_key: state.signer.verifying_key().to_bytes().to_vec(),
+            };
+            Ok(Json(response))
+        }
+        Err(e) => {
+            return Err((StatusCode::FORBIDDEN, format!("invalid proof: {e:?}")));
+        }
+    }
 }
 
-struct AppState {
-    verifier: Verifier,
+#[mockall::automock]
+trait Verifier {
+    fn verify(
+        &self,
+        proof: &post::prove::Proof<'static>,
+        metadata: &post::metadata::ProofMetadata,
+    ) -> Result<(), String>;
+}
+
+struct PostVerifier {
+    verifier: post::verification::Verifier,
     cfg: ProofConfig,
     init_cfg: InitConfig,
+}
+
+impl Verifier for PostVerifier {
+    fn verify(
+        &self,
+        proof: &post::prove::Proof<'_>,
+        metadata: &post::metadata::ProofMetadata,
+    ) -> Result<(), String> {
+        self.verifier
+            .verify(proof, metadata, &self.cfg, &self.init_cfg, Mode::All)
+            .map_err(|e| format!("{e:?}"))
+    }
+}
+
+struct Certifier {
+    verifier: Arc<dyn Verifier + Send + Sync>,
     signer: SigningKey,
+    expiry: Option<chrono::Duration>,
+}
+
+impl Certifier {
+    pub fn certify(
+        &self,
+        proof: &post::prove::Proof<'static>,
+        metadata: &post::metadata::ProofMetadata,
+    ) -> Result<(Vec<u8>, Signature), String> {
+        self.verifier.verify(proof, metadata)?;
+
+        let cert = self.create_certificate(&metadata.node_id);
+        let cert_encoded = cert.encode();
+        let signature = self.signer.sign(&cert_encoded);
+
+        Ok((cert_encoded.to_vec(), signature))
+    }
+
+    fn create_certificate(&self, id: &[u8; 32]) -> Certificate {
+        let expiration = self.expiry.map(|exp| (Utc::now() + exp).timestamp() as u64);
+        Certificate {
+            pub_key: id.to_vec(),
+            expiration: expiration.map(Compact),
+        }
+    }
 }
 
 pub fn new(
@@ -74,17 +138,141 @@ pub fn new(
     init_cfg: InitConfig,
     signer: SigningKey,
     randomx_mode: RandomXMode,
+    expiry: Option<chrono::Duration>,
 ) -> Router {
-    let state = AppState {
-        verifier: Verifier::new(Box::new(
+    let verifier = Arc::new(PostVerifier {
+        verifier: post::verification::Verifier::new(Box::new(
             PoW::new(randomx_mode.into()).expect("creating RandomX PoW verifier"),
         )),
         cfg,
         init_cfg,
+    });
+    let certifier = Certifier {
+        verifier,
         signer,
+        expiry,
     };
 
     Router::new()
         .route("/certify", post(certify))
-        .with_state(Arc::new(state))
+        .with_state(Arc::new(certifier))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::{Certificate, Certifier, MockVerifier};
+    use chrono::{DateTime, Duration, Utc};
+    use ed25519_dalek::SigningKey;
+    use parity_scale_codec::{Compact, Decode, Encode};
+    use post::{metadata::ProofMetadata, prove::Proof};
+    #[test]
+    fn serialize() {
+        let cert = Certificate {
+            pub_key: vec![
+                1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+                10, 11, 12, 13, 14, 15, 16,
+            ],
+            expiration: Some(Compact(
+                DateTime::parse_from_rfc3339("1996-12-19T16:39:57-08:00")
+                    .unwrap()
+                    .to_utc()
+                    .timestamp() as u64,
+            )),
+        };
+        let b = &cert.encode();
+        println!("{}", base64::encode(b));
+
+        let val: u64 = 0x123456789abcdef0;
+
+        let compact = Compact(val);
+        let encoded = compact.encode();
+        println!("{}", base64::encode(&encoded));
+    }
+
+    #[test]
+    fn certify_invalid_post() {
+        let mut verifier = MockVerifier::new();
+        verifier
+            .expect_verify()
+            .returning(|_, _| Err("invalid".to_string()));
+
+        let certifier = Certifier {
+            verifier: Arc::new(verifier),
+            signer: SigningKey::generate(&mut rand::rngs::OsRng),
+            expiry: None,
+        };
+
+        let proof = Proof {
+            nonce: 0,
+            indices: std::borrow::Cow::Owned(vec![1, 2, 3]),
+            pow: 0,
+        };
+
+        let metadata = ProofMetadata {
+            node_id: [7; 32],
+            commitment_atx_id: [0u8; 32],
+            challenge: [0; 32],
+            num_units: 1,
+        };
+
+        certifier
+            .certify(&proof, &metadata)
+            .expect_err("certification should fail");
+    }
+
+    #[test]
+    fn ceritify_valid_post() {
+        let mut verifier = MockVerifier::new();
+        verifier.expect_verify().returning(|_, _| Ok(()));
+        let certifier = Certifier {
+            verifier: Arc::new(verifier),
+            signer: SigningKey::generate(&mut rand::rngs::OsRng),
+            expiry: None,
+        };
+
+        let proof = Proof {
+            nonce: 0,
+            indices: std::borrow::Cow::Owned(vec![1, 2, 3]),
+            pow: 0,
+        };
+
+        let metadata = ProofMetadata {
+            node_id: [7; 32],
+            commitment_atx_id: [0u8; 32],
+            challenge: [0; 32],
+            num_units: 1,
+        };
+
+        let (encoded, signature) = certifier
+            .certify(&proof, &metadata)
+            .expect("certification should succeed");
+
+        certifier
+            .signer
+            .verify(&encoded, &signature)
+            .expect("signature should be valid");
+
+        let cert = Certificate::decode(&mut encoded.as_slice())
+            .expect("decoding certificate should succeed");
+        assert!(cert.expiration.is_none());
+    }
+
+    #[test]
+    fn create_cert_with_expiry() {
+        let expiry = Duration::try_days(1).unwrap();
+        let certifier = Certifier {
+            verifier: Arc::new(MockVerifier::new()),
+            signer: SigningKey::generate(&mut rand::rngs::OsRng),
+            expiry: Some(expiry),
+        };
+
+        let started = Utc::now();
+        let cert = certifier.create_certificate(&[7u8; 32]);
+
+        let expiration = cert.expiration.unwrap().0;
+        assert!(expiration >= (started + expiry).timestamp() as u64);
+        assert!(expiration <= (chrono::Utc::now() + expiry).timestamp() as u64);
+    }
 }

--- a/certifier/src/configuration.rs
+++ b/certifier/src/configuration.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::{path::Path, time::Duration};
 
 use ed25519_dalek::SecretKey;
 use post::pow::randomx::RandomXFlag;
@@ -56,10 +56,10 @@ pub struct Config {
 
     #[serde(
         default,
-        deserialize_with = "duration_str::deserialize_option_duration_chrono"
+        deserialize_with = "duration_str::deserialize_option_duration"
     )]
     /// The time after which the certificates expire.
-    pub certificate_expiration: Option<chrono::Duration>,
+    pub certificate_expiration: Option<Duration>,
 
     /// Address to expose metrics on.
     /// Metrics are disabled if not configured.

--- a/certifier/src/configuration.rs
+++ b/certifier/src/configuration.rs
@@ -54,6 +54,13 @@ pub struct Config {
     #[serde(default)]
     pub randomx_mode: RandomXMode,
 
+    #[serde(
+        default,
+        deserialize_with = "duration_str::deserialize_option_duration_chrono"
+    )]
+    /// The time after which the certificates expire.
+    pub certificate_expiration: Option<chrono::Duration>,
+
     /// Address to expose metrics on.
     /// Metrics are disabled if not configured.
     pub metrics: Option<std::net::SocketAddr>,

--- a/certifier/src/lib.rs
+++ b/certifier/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod certifier;
 pub mod configuration;
+pub mod time;

--- a/certifier/src/main.rs
+++ b/certifier/src/main.rs
@@ -82,7 +82,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         config.max_concurrent_requests
     );
     if let Some(expiry) = config.certificate_expiration {
-        info!("generated certificates will expire after {expiry}");
+        info!("generated certificates will expire after {expiry:?}");
     } else {
         info!("generated certificates won't expire");
     }

--- a/certifier/src/main.rs
+++ b/certifier/src/main.rs
@@ -81,12 +81,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "max concurrent requests: {}",
         config.max_concurrent_requests
     );
+    if let Some(expiry) = config.certificate_expiration {
+        info!("generated certificates will expire after {expiry}");
+    } else {
+        info!("generated certificates won't expire");
+    }
 
     let mut app = certifier::certifier::new(
         config.post_cfg,
         config.init_cfg,
         signer,
         config.randomx_mode,
+        config.certificate_expiration,
     )
     .layer(ConcurrencyLimitLayer::new(config.max_concurrent_requests));
 

--- a/certifier/src/time.rs
+++ b/certifier/src/time.rs
@@ -1,0 +1,7 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub fn unix_timestamp(t: SystemTime) -> u64 {
+    t.duration_since(UNIX_EPOCH)
+        .expect("system time is before unix epoch")
+        .as_secs()
+}

--- a/certifier/tests/test_certify.rs
+++ b/certifier/tests/test_certify.rs
@@ -1,39 +1,34 @@
 use std::{future::IntoFuture, net::SocketAddr, str::FromStr, sync::atomic::AtomicBool};
 
-use certifier::{certifier::CertifyRequest, configuration::RandomXMode};
+use certifier::{
+    certifier::{Certificate, CertifyRequest},
+    configuration::RandomXMode,
+};
 use ed25519_dalek::SigningKey;
+use parity_scale_codec::Decode;
 use post::{
     config::{Cores, InitConfig, ProofConfig, ScryptParams},
     initialize::{CpuInitializer, Initialize},
     metadata::ProofMetadata,
     pow::randomx::RandomXFlag,
-    prove::{self, generate_proof},
+    prove::{self, generate_proof, Proof},
 };
 use reqwest::StatusCode;
 use tokio::net::TcpListener;
 
-#[tokio::test]
-async fn test_certificate_post_proof() {
+fn gen_proof(
+    cfg: ProofConfig,
+    init_cfg: InitConfig,
+    id: [u8; 32],
+) -> (Proof<'static>, ProofMetadata) {
     // Initialize some data
     let challenge = b"hello world, challenge me!!!!!!!";
     let datadir = tempfile::tempdir().unwrap();
 
-    let cfg = ProofConfig {
-        k1: 20,
-        k2: 10,
-        pow_difficulty: [0xFF; 32],
-    };
-    let init_cfg = InitConfig {
-        min_num_units: 1,
-        max_num_units: 1000,
-        labels_per_unit: 200,
-        scrypt: ScryptParams::new(2, 1, 1),
-    };
-
     let metadata = CpuInitializer::new(init_cfg.scrypt)
         .initialize(
             datadir.path(),
-            &[0u8; 32],
+            &id,
             &[0u8; 32],
             init_cfg.labels_per_unit,
             2,
@@ -58,9 +53,25 @@ async fn test_certificate_post_proof() {
     .unwrap();
     let metadata = ProofMetadata::new(metadata, *challenge);
 
+    (proof, metadata)
+}
+
+#[tokio::test]
+async fn test_certificate_post_proof() {
+    let cfg = ProofConfig {
+        k1: 20,
+        k2: 10,
+        pow_difficulty: [0xFF; 32],
+    };
+    let init_cfg = InitConfig {
+        min_num_units: 1,
+        max_num_units: 1000,
+        labels_per_unit: 200,
+        scrypt: ScryptParams::new(2, 1, 1),
+    };
     // Spawn the certifier service
     let signer = SigningKey::generate(&mut rand::rngs::OsRng);
-    let app = certifier::certifier::new(cfg, init_cfg, signer, RandomXMode::Light);
+    let app = certifier::certifier::new(cfg, init_cfg, signer.clone(), RandomXMode::Light, None);
     let listener = TcpListener::bind(SocketAddr::from_str("127.0.0.1:0").unwrap())
         .await
         .unwrap();
@@ -70,8 +81,19 @@ async fn test_certificate_post_proof() {
 
     let client = reqwest::Client::new();
 
+    let node_id = [
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
+        12, 13, 14, 15, 16,
+    ];
+    let (proof, metadata) = gen_proof(cfg, init_cfg, node_id);
+
     // Certify with a valid proof
     let req = CertifyRequest { proof, metadata };
+
+    // save as json to file
+    let json = serde_json::to_string(&req).unwrap();
+    std::fs::write("certify_request.json", json).unwrap();
+
     let response = client
         .post(format!("http://{addr}/certify"))
         .json(&req)
@@ -79,6 +101,14 @@ async fn test_certificate_post_proof() {
         .await
         .unwrap();
     assert!(response.status().is_success());
+
+    // verify the certificate
+    let data = response.bytes().await.unwrap();
+    let cert_resp = serde_json::from_slice::<certifier::certifier::CertifyResponse>(&data).unwrap();
+    let cert = Certificate::decode(&mut cert_resp.certificate.as_slice()).unwrap();
+    assert!(cert.expiration.is_none());
+    let signature = ed25519_dalek::Signature::from_slice(&cert_resp.signature).unwrap();
+    assert!(signer.verify(&cert_resp.certificate, &signature).is_ok());
 
     // Try to certify with an invalid proof
     let mut invalid_req = req;
@@ -90,4 +120,61 @@ async fn test_certificate_post_proof() {
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn test_certificate_post_proof_with_expiration() {
+    let cfg = ProofConfig {
+        k1: 20,
+        k2: 10,
+        pow_difficulty: [0xFF; 32],
+    };
+    let init_cfg = InitConfig {
+        min_num_units: 1,
+        max_num_units: 1000,
+        labels_per_unit: 200,
+        scrypt: ScryptParams::new(2, 1, 1),
+    };
+    // Spawn the certifier service
+    let signer = SigningKey::generate(&mut rand::rngs::OsRng);
+    let expiry = chrono::Duration::try_days(1).unwrap();
+    let app = certifier::certifier::new(
+        cfg,
+        init_cfg,
+        signer.clone(),
+        RandomXMode::Light,
+        Some(expiry),
+    );
+    let listener = TcpListener::bind(SocketAddr::from_str("127.0.0.1:0").unwrap())
+        .await
+        .unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = axum::serve(listener, app.into_make_service());
+    tokio::spawn(server.into_future());
+
+    let client = reqwest::Client::new();
+
+    let node_id = [0u8; 32];
+    let (proof, metadata) = gen_proof(cfg, init_cfg, node_id);
+
+    // Certify with a valid proof
+    let req_time = chrono::Utc::now();
+    let req = CertifyRequest { proof, metadata };
+    let response = client
+        .post(format!("http://{addr}/certify"))
+        .json(&req)
+        .send()
+        .await
+        .unwrap();
+    assert!(response.status().is_success());
+
+    // verify the certificate
+    let data = response.bytes().await.unwrap();
+    let cert_resp = serde_json::from_slice::<certifier::certifier::CertifyResponse>(&data).unwrap();
+    let cert = Certificate::decode(&mut cert_resp.certificate.as_slice()).unwrap();
+    assert!(cert.expiration.unwrap().0 >= (req_time + expiry).timestamp() as u64);
+    assert!(cert.expiration.unwrap().0 <= (chrono::Utc::now() + expiry).timestamp() as u64);
+
+    let signature = ed25519_dalek::Signature::from_slice(&cert_resp.signature).unwrap();
+    assert!(signer.verify(&cert_resp.certificate, &signature).is_ok());
 }

--- a/initializer/Cargo.toml
+++ b/initializer/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-base64 = "0.21.0"
+base64 = "0.22.0"
 clap = { version = "4.5.3", features = ["derive"] }
 post-rs = { path = "../" }
 scrypt-ocl = { path = "../scrypt-ocl" }


### PR DESCRIPTION
Support for certificates with an optional expiration date. A certificate is a scale-encoded combination of the node's ID and (optional) expiration time. If the expiration time is `None`, the certificate does not expire.

The certifier will create expiring certificates if the expiration duration is set in the config.