### PR TITLE
[service] Increase keep-alive interval to 10min

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,7 +483,7 @@ checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 
 [[package]]
 name = "certifier"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "axum 0.7.4",
  "axum-prometheus",
@@ -1653,7 +1653,7 @@ dependencies = [
 
 [[package]]
 name = "initializer"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "base64",
  "clap",
@@ -2398,7 +2398,7 @@ checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 
 [[package]]
 name = "post-cbindings"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "cbindgen",
  "log",
@@ -2409,7 +2409,7 @@ dependencies = [
 
 [[package]]
 name = "post-rs"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "aes",
  "bitvec",
@@ -2541,7 +2541,7 @@ dependencies = [
 
 [[package]]
 name = "profiler"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "clap",
  "env_logger",
@@ -3158,7 +3158,7 @@ dependencies = [
 
 [[package]]
 name = "scrypt-ocl"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "log",
  "ocl",
@@ -3301,7 +3301,7 @@ dependencies = [
 
 [[package]]
 name = "service"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "async-stream",
  "axum 0.7.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 [package]
 name = "post-rs"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 
 [lib]

--- a/certifier/Cargo.toml
+++ b/certifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "certifier"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 
 [dependencies]

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "post-cbindings"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 
 

--- a/initializer/Cargo.toml
+++ b/initializer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "initializer"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/profiler/Cargo.toml
+++ b/profiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profiler"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 
 [dependencies]

--- a/scrypt-ocl/Cargo.toml
+++ b/scrypt-ocl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrypt-ocl"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 
 [dependencies]

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "service"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 
 [lib]

--- a/service/src/client.rs
+++ b/service/src/client.rs
@@ -70,7 +70,7 @@ impl<S: PostService> ServiceClient<S> {
     ) -> eyre::Result<Self> {
         let endpoint = Channel::builder(address.parse()?)
             .keep_alive_timeout(Duration::from_secs(20))
-            .http2_keep_alive_interval(Duration::from_secs(60));
+            .http2_keep_alive_interval(Duration::from_secs(10 * 60));
         let endpoint = match tls {
             Some((domain, cert, identity)) => {
                 let domain = match domain {


### PR DESCRIPTION
The 1-minute interval is too low and caused the server side to eventually respond with GOAWAY and close the connection with "too many pings" message.