### PR TITLE
feat: allow interrupts on proof generation

### DIFF
--- a/service/src/service.rs
+++ b/service/src/service.rs
@@ -3,7 +3,10 @@
 use std::{
     ops::{Range, RangeInclusive},
     path::PathBuf,
-    sync::{atomic::AtomicBool, Arc, Mutex},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
 };
 
 use eyre::Context;
@@ -212,6 +215,11 @@ impl crate::client::PostService for PostService {
 
     fn get_metadata(&self) -> &PostMetadata {
         &self.metadata
+    }
+
+    fn interrupt_proof(&self) -> eyre::Result<()> {
+        self.stop.clone().store(true, Ordering::Relaxed);
+        Ok(())
     }
 }
 


### PR DESCRIPTION
This change adds support to interrupting and stopping the proof generation via a new RPC call that simply sets the `AtomicBool` on the service to `true`, resulting in the proof generation to be cancelled the same as in a shutdown.

It might be useful to add a thread join on the handle the same way that the shutdown is doing, wdyt @poszu?

This doesn't help with cancelling the proof generation via FFI (which I think can still be used by the `post` go tool). I tried to also add that but got lost in the go->c->rust rabbit-hole (tried to inject a callback that would provide a `bool` from the go-code in order to stop the execution, the same way that is done currently with the `AtomicBool`).



Closes #81 
Depends on https://github.com/spacemeshos/api/pull/366/files
