### PR TITLE
Fix flaky certifier UTs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,8 +495,6 @@ dependencies = [
  "parity-scale-codec",
  "post-rs",
  "rand",
- "reqwest",
- "secrecy",
  "serde",
  "serde_json",
  "serde_with",
@@ -3175,16 +3173,6 @@ dependencies = [
  "regex",
  "rstest",
  "thiserror",
-]
-
-[[package]]
-name = "secrecy"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
-dependencies = [
- "serde",
- "zeroize",
 ]
 
 [[package]]

--- a/certifier/Cargo.toml
+++ b/certifier/Cargo.toml
@@ -18,7 +18,6 @@ ed25519-dalek = { version = "2.1.1", features = ["rand_core"] }
 clap = { version = "4.5.16", features = ["derive", "env"] }
 hex = "0.4.3"
 config = "0.14.0"
-secrecy = { version = "0.8.0", features = ["serde"] }
 tracing = { version = "0.1.40", features = ["log"] }
 tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
@@ -36,5 +35,4 @@ mockall = "0.13.0"
 
 [dev-dependencies]
 axum-test = "15.6.0"
-reqwest = { version = "0.12.7", features = ["json"] }
 tempfile = "3.12.0"


### PR DESCRIPTION
The tests were flaky because the server sometimes hadn't started yet when the client was doing a request.

Additionally, removed 2 unused deps.