### PR TITLE
Fix post-service connecting over TLS

### DIFF
--- a/service/src/client.rs
+++ b/service/src/client.rs
@@ -109,10 +109,10 @@ impl<S: PostService> ServiceClient<S> {
                     self.endpoint.uri(),
                     attempt
                 );
-                match PostServiceClient::connect(self.endpoint.clone()).await {
-                    Ok(client) => break client,
+                match self.endpoint.connect().await {
+                    Ok(channel) => break PostServiceClient::new(channel),
                     Err(e) => {
-                        log::info!("could not connect to the node: {e}");
+                        log::info!("could not connect to the node: {e:?}");
                         if let Some(max) = max_retries {
                             eyre::ensure!(attempt <= max, "max retries ({max}) reached");
                         }

--- a/service/tests/server/mod.rs
+++ b/service/tests/server/mod.rs
@@ -110,13 +110,12 @@ impl TestServer {
         let listener = TcpListener::bind("[::1]:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
 
-        let mut server = if let Some(tls) = &tls {
+        let mut server = Server::builder();
+        if let Some(tls) = &tls {
             let tls = ServerTlsConfig::new()
                 .identity(tls.server.clone())
                 .client_ca_root(tls.client_ca_cert.clone());
-            Server::builder().tls_config(tls).unwrap()
-        } else {
-            Server::builder()
+            server = server.tls_config(tls).unwrap();
         };
 
         let handle = tokio::spawn(

--- a/service/tests/server/mod.rs
+++ b/service/tests/server/mod.rs
@@ -11,7 +11,7 @@ use tokio::net::TcpListener;
 use tokio::sync::{broadcast, mpsc, oneshot};
 use tokio_stream::wrappers::TcpListenerStream;
 use tokio_stream::{Stream, StreamExt};
-use tonic::transport::Server;
+use tonic::transport::{Certificate, Identity, Server, ServerTlsConfig};
 use tonic::{Request, Response, Status};
 
 use post_service::client::spacemesh_v1::{
@@ -81,10 +81,19 @@ impl post_service_server::PostService for TestPostService {
     }
 }
 
+pub(crate) struct TlsConfig {
+    pub server_ca_cert: Certificate,
+    pub server: Identity,
+
+    pub client_ca_cert: Certificate,
+    pub client: Identity,
+}
+
 pub struct TestServer {
     pub connected: broadcast::Receiver<mpsc::Sender<TestNodeRequest>>,
     handle: tokio::task::JoinHandle<Result<(), tonic::transport::Error>>,
     addr: std::net::SocketAddr,
+    tls: Option<TlsConfig>,
 }
 
 impl Drop for TestServer {
@@ -94,15 +103,24 @@ impl Drop for TestServer {
 }
 
 impl TestServer {
-    pub async fn new() -> Self {
+    pub async fn new(tls: Option<TlsConfig>) -> Self {
         let mut test_node = TestPostService::new();
         let reg = test_node.register_for_connections();
 
         let listener = TcpListener::bind("[::1]:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
 
-        let handle = tokio::spawn(
+        let mut server = if let Some(tls) = &tls {
+            let tls = ServerTlsConfig::new()
+                .identity(tls.server.clone())
+                .client_ca_root(tls.client_ca_cert.clone());
+            Server::builder().tls_config(tls).unwrap()
+        } else {
             Server::builder()
+        };
+
+        let handle = tokio::spawn(
+            server
                 .add_service(post_service_server::PostServiceServer::new(test_node))
                 .serve_with_incoming(TcpListenerStream::new(listener)),
         );
@@ -111,6 +129,7 @@ impl TestServer {
             connected: reg,
             handle,
             addr,
+            tls,
         }
     }
 
@@ -118,7 +137,19 @@ impl TestServer {
     where
         S: PostService,
     {
-        ServiceClient::new(format!("http://{}", self.addr), None, service).unwrap()
+        let tls = self.tls.as_ref().map(|tls| {
+            (
+                Some("localhost".to_string()),
+                tls.server_ca_cert.clone(),
+                tls.client.clone(),
+            )
+        });
+        let scheme = match tls {
+            Some(_) => "https",
+            None => "http",
+        };
+
+        ServiceClient::new(format!("{scheme}://{}", self.addr), tls, service).unwrap()
     }
 
     pub async fn generate_proof(

--- a/service/tests/test_operator.rs
+++ b/service/tests/test_operator.rs
@@ -44,7 +44,7 @@ async fn test_gen_proof_in_progress() {
         .unwrap(),
     );
 
-    let mut test_server = TestServer::new().await;
+    let mut test_server = TestServer::new(None).await;
     let client = test_server.create_client(service.clone());
     tokio::spawn(client.run(None, time::Duration::from_secs(1)));
 


### PR DESCRIPTION
Fix the issue found in go-spacemesh CI where the post-service cannot connect to the node using TLS. The failed job: https://github.com/spacemeshos/go-spacemesh/actions/runs/10797643894/job/29979007952?pr=6323

Added a test verifying that the post-service client can connect to the test server with TLS and manually tested integration in go-spacemesh (`Test_GenerateProof_TLS` test) on Linux and Mac.