### PR TITLE
Change deprecated 'crate_type' to 'crate-type'

### DIFF
--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [lib]
 name = "post"
-crate_type = ["staticlib", "cdylib"]
+crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
 log = { version = "0.4.22", features = ["std"] }


### PR DESCRIPTION
Fixes warning:
```
warning: /home/bartosz/workspace/post-rs/ffi/Cargo.toml: `crate_type` is deprecated in favor of `crate-type` and will not work in the 2024 edition
```