### PR TITLE
Fix benchmarks not building

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,11 @@ jobs:
           unzip -j OpenCL-SDK-v2023.04.17-Win-x64.zip OpenCL-SDK-v2023.04.17-Win-x64/lib/OpenCL.lib
       - uses: Swatinem/rust-cache@v2
 
+      - name: Benchmarks
+        run: cargo bench --no-run
+        env:
+          RUSTFLAGS: ${{ matrix.rustflags }}
+
       - name: Tests
         run: cargo test --workspace --exclude scrypt-ocl
         env:

--- a/README.md
+++ b/README.md
@@ -2,21 +2,32 @@
 
 # Rust implementation of PoST protocol
 
-👉 Refer to https://github.com/spacemeshos/protocol/blob/master/post.md for more information on Proof of Space-Time protocol.
+👉 Refer to <https://github.com/spacemeshos/protocol/blob/master/post.md> for more information on Proof of Space-Time
+protocol.
 
 Includes:
+
 - initializing data:
-  * on CPU with [scrypt-jane](https://github.com/floodyberry/scrypt-jane)
-  * on GPU with OpenCL
+  - on CPU with [scrypt-jane](https://github.com/floodyberry/scrypt-jane)
+  - on GPU with OpenCL
 - generating PoST
 - verifying PoST
 
 ## Build dependencies
+
 ### Bindgen
-[Bindgen](https://rust-lang.github.io/rust-bindgen/introduction.html) is required to generate bindings to C for calling the scrypt-jane C library (indirect dependency from [scrypt-jane-rs](https://github.com/spacemeshos/scrypt-jane-rs)). It depends on **clang**. Follow [these instructions](https://rust-lang.github.io/rust-bindgen/requirements.html#installing-clang) to install it.
+
+[Bindgen](https://rust-lang.github.io/rust-bindgen/introduction.html) is required to generate bindings to C for calling
+the scrypt-jane C library (indirect dependency from [scrypt-jane-rs](https://github.com/spacemeshos/scrypt-jane-rs)). It
+depends on **clang**. Follow [these
+instructions](https://rust-lang.github.io/rust-bindgen/requirements.html#installing-clang) to install it.
 
 ### Randomx-rs
-[RandomX](https://github.com/tevador/randomx), that [randomx-rs](https://github.com/spacemeshos/randomx-rs) depends on, requires **cmake**. Follow [these instructions](https://github.com/spacemeshos/randomx-rs#build-dependencies) to install it.
+
+[RandomX](https://github.com/tevador/randomx), that [randomx-rs](https://github.com/spacemeshos/randomx-rs) depends on,
+requires **cmake**. Follow [these instructions](https://github.com/spacemeshos/randomx-rs#build-dependencies) to install
+it.
 
 ## Post Service
+
 Please refer to [service README](service/README.md) for instructions.

--- a/benches/verifying.rs
+++ b/benches/verifying.rs
@@ -54,7 +54,7 @@ fn verifying(c: &mut Criterion) {
         pow_flags,
         stop,
         NoopProgressReporter {},
-        pow_prover,
+        &pow_prover,
     )
     .unwrap();
     let metadata = ProofMetadata::new(metadata, *challenge);


### PR DESCRIPTION
I fixed a minor issue in the benchmarks that prevented them from being built and run. Additionally I added another step to the CI to ensure that benchmarks are compiled without issues. Since they take quite a while to execute I chose to just build them.