### PR TITLE
fix: add mock prover par expectation

### DIFF
--- a/benches/proving.rs
+++ b/benches/proving.rs
@@ -49,6 +49,7 @@ fn prover_bench(c: &mut Criterion) {
                     .expect_prove()
                     .times(nonces as usize / 16)
                     .returning(|_, _, _, _| Ok(0));
+                pow_prover.expect_par().returning(|| false);
                 let prover =
                     Prover8_56::new(CHALLENGE, 0..nonces, params, &pow_prover, &[7; 32]).unwrap();
                 b.iter(|| {

--- a/profiler/src/main.rs
+++ b/profiler/src/main.rs
@@ -237,6 +237,7 @@ fn proving(args: ProvingArgs) -> eyre::Result<()> {
 
     let mut pow_prover = pow::MockProver::new();
     pow_prover.expect_prove().returning(|_, _, _, _| Ok(0));
+    pow_prover.expect_par().returning(|| false);
     let prover = Prover8_56::new(challenge, 0..args.nonces, params, &pow_prover, &[7; 32])?;
 
     let mut total_time = time::Duration::from_secs(0);


### PR DESCRIPTION
Missing expect call caused the profiler to unexpectedly exit.

fixes https://github.com/spacemeshos/smapp/issues/1801