### PR TITLE
Fix missing libssl library in Certifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "certifier"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "axum",
  "axum-prometheus",
@@ -2083,7 +2083,7 @@ dependencies = [
 
 [[package]]
 name = "initializer"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -2186,7 +2186,7 @@ dependencies = [
 
 [[package]]
 name = "k2pow-service"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "axum",
  "axum-test",
@@ -2970,7 +2970,7 @@ checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 
 [[package]]
 name = "post-cbindings"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "cbindgen",
  "log",
@@ -2981,7 +2981,7 @@ dependencies = [
 
 [[package]]
 name = "post-rs"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "aes",
  "bitvec",
@@ -3133,7 +3133,7 @@ dependencies = [
 
 [[package]]
 name = "profiler"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "clap",
  "env_logger",
@@ -3752,7 +3752,7 @@ dependencies = [
 
 [[package]]
 name = "scrypt-ocl"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "log",
  "ocl",
@@ -3896,7 +3896,7 @@ dependencies = [
 
 [[package]]
 name = "service"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "async-stream",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 
 [package]
 name = "post-rs"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 
 [lib]

--- a/certifier/Cargo.toml
+++ b/certifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "certifier"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 
 [dependencies]

--- a/certifier/Dockerfile
+++ b/certifier/Dockerfile
@@ -25,4 +25,10 @@ RUN cargo build --release -p certifier --bin certifier
 FROM debian:bookworm-slim AS runtime
 WORKDIR /certifier
 COPY --from=builder /certifier/target/release/certifier /usr/local/bin
+RUN set -ex \
+    && apt-get update --fix-missing \
+    && apt-get install -qy --no-install-recommends \
+    ca-certificates \
+    libssl3 \
+    && rm -rf /var/lib/apt/lists/*
 ENTRYPOINT ["/usr/local/bin/certifier"]

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "post-cbindings"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 
 [lib]

--- a/initializer/Cargo.toml
+++ b/initializer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "initializer"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/k2pow-service/Cargo.toml
+++ b/k2pow-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k2pow-service"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 
 [dependencies]

--- a/profiler/Cargo.toml
+++ b/profiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profiler"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 
 [dependencies]

--- a/scrypt-ocl/Cargo.toml
+++ b/scrypt-ocl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrypt-ocl"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 
 [dependencies]

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "service"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 
 [[bin]]

--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -25,7 +25,9 @@ RUN cargo build --release -p service --bin post-service
 FROM debian:bookworm-slim AS runtime
 WORKDIR /service
 COPY --from=builder /service/target/release/post-service /usr/local/bin
-RUN apt-get update && apt-get install -y\
+RUN set -ex \
+    && apt-get update --fix-missing \
+    && apt-get install -qy --no-install-recommends \
     ca-certificates \
     libssl3 \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The newest certifier docker image doesn't start with error:

```
/usr/local/bin/certifier: error while loading shared libraries: libssl.so.3: cannot open shared object file: No such file or directory
```