### PR TITLE
log error when failed to read POS data from file

### DIFF
--- a/profiler/src/main.rs
+++ b/profiler/src/main.rs
@@ -245,7 +245,8 @@ fn proving(args: ProvingArgs) -> eyre::Result<()> {
 
     while total_time < Duration::from_secs(args.duration) {
         let file = util::open_without_cache(&file_path)?;
-        let reader = BatchingReader::new(BufReader::new(file), 0, batch_size, total_size);
+        let file_id = format!("{}", file_path.display());
+        let reader = BatchingReader::new(file_id, BufReader::new(file), 0, batch_size, total_size);
         let start = time::Instant::now();
         pool.install(|| {
             reader.par_bridge().for_each(|batch| {


### PR DESCRIPTION
Added an error log message that will print:
- the path of the file that it failed to read from,
- the position in this file
- the total size of the file
- the actual error

Previously, the error was swallowed without notifying the user something was wrong.